### PR TITLE
remove redundant wording from changelog title

### DIFF
--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -34,7 +34,7 @@ sections:
   - Bugfixes
 - - known_issues
   - Known Issues
-title: Community OpenWrt Release Notes
+title: Community OpenWrt
 trivial_section_name: trivial
 use_fqcn: true
 vcs: auto


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The words "Release Notes" are added automatically, no need to write them in the title