### PR TITLE
docs: adjust strict file operations claims in modules

### DIFF
--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -58,4 +58,7 @@ options: {}
 attributes:
   safe_file_operations:
     description: Uses Ansible's strict file operation functions to ensure proper permissions and avoid data corruption.
+    support: none
+    details:
+      - This module uses basic shell commands for file operations and does not implement Ansible's atomic file operation functions.
 """

--- a/plugins/modules/copy.py
+++ b/plugins/modules/copy.py
@@ -23,8 +23,6 @@ attributes:
     support: full
   diff_mode:
     support: full
-  safe_file_operations:
-    support: full
 options:
   src:
     description:

--- a/plugins/modules/file.py
+++ b/plugins/modules/file.py
@@ -20,8 +20,6 @@ attributes:
     support: full
   diff_mode:
     support: full
-  safe_file_operations:
-    support: full
 options:
   path:
     description:

--- a/plugins/modules/lineinfile.py
+++ b/plugins/modules/lineinfile.py
@@ -21,8 +21,6 @@ attributes:
     support: full
   diff_mode:
     support: full
-  safe_file_operations:
-    support: full
 options:
   path:
     description:

--- a/plugins/modules/sysctl.py
+++ b/plugins/modules/sysctl.py
@@ -20,8 +20,6 @@ attributes:
     support: full
   diff_mode:
     support: none
-  safe_file_operations:
-    support: full
 options:
   name:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adjust documentation claims that modules were using Ansible's strict file operations.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/doc_fragments/attributes.py
plugins/modules/copy.py
plugins/modules/file.py
plugins/modules/lineinfile.py
plugins/modules/sysctl.py
