### PR TITLE
docs: use common file args in modules

### DIFF
--- a/plugins/doc_fragments/attributes.py
+++ b/plugins/doc_fragments/attributes.py
@@ -58,4 +58,7 @@ options: {}
 attributes:
   safe_file_operations:
     description: Uses Ansible's strict file operation functions to ensure proper permissions and avoid data corruption.
+    support: none
+    details:
+      - This module uses basic shell commands for file operations and does not implement Ansible's atomic file operation functions.
 """

--- a/plugins/doc_fragments/file_common_arguments.py
+++ b/plugins/doc_fragments/file_common_arguments.py
@@ -1,0 +1,41 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+
+class ModuleDocFragment:
+    DOCUMENTATION = r"""
+options:
+  mode:
+    description:
+      - Permissions for the file or directory.
+      - Can be specified as an octal number (for example, V('0644'), V('1777')) or symbolic mode (like V('u+rwx')).
+      - When using octal notation, quote the value to ensure it is treated as a string.
+      - If not specified, permissions may be determined by the system default C(umask) or remain unchanged.
+      - Not applied to symlinks when O(follow=false).
+    type: str
+  owner:
+    description:
+      - User name that should own the file or directory.
+      - Passed directly to the C(chown) command.
+      - If not specified, ownership is not changed.
+      - Not applied to symlinks when O(follow=false).
+    type: str
+  group:
+    description:
+      - Group name that should own the file or directory.
+      - Passed directly to the C(chgrp) command.
+      - If not specified, group ownership is not changed.
+      - Not applied to symlinks when O(follow=false).
+    type: str
+  follow:
+    description:
+      - Whether to follow symlinks when setting file attributes.
+      - When V(false), symlinks are not followed and attributes are set on the link itself (where supported).
+      - When V(true), attributes are set on the symlink target.
+      - Affects how O(mode), O(owner), and O(group) are applied.
+    type: bool
+    default: false
+"""

--- a/plugins/modules/copy.py
+++ b/plugins/modules/copy.py
@@ -18,12 +18,11 @@ author:
 extends_documentation_fragment:
   - community.openwrt.attributes
   - community.openwrt.attributes.files
+  - community.openwrt.file_common_arguments
 attributes:
   check_mode:
     support: full
   diff_mode:
-    support: full
-  safe_file_operations:
     support: full
 options:
   src:
@@ -64,38 +63,6 @@ options:
     default: true
     aliases:
       - thirsty
-  mode:
-    description:
-      - Permissions of the destination file or directory.
-      - Can be specified as an octal number (for example, V('0644'), V('1777')) or symbolic mode (like V('u+rwx')).
-      - When using octal notation, quote the value to ensure it is treated as a string.
-      - The module attempts to convert numeric mode values to 4-digit octal format.
-      - If not specified, the system default C(umask) determines permissions for new files.
-      - For existing files, permissions remain unchanged unless O(mode) is explicitly set.
-      - Not applied to symlinks when O(follow=false).
-    type: str
-  owner:
-    description:
-      - User name that should own the file.
-      - Passed directly to the C(chown) command.
-      - If not specified, ownership is not changed.
-      - Not applied to symlinks when O(follow=false).
-    type: str
-  group:
-    description:
-      - Group name that should own the file.
-      - Passed directly to the C(chgrp) command.
-      - If not specified, group ownership is not changed.
-      - Not applied to symlinks when O(follow=false).
-    type: str
-  follow:
-    description:
-      - Whether to follow symlinks when setting file attributes.
-      - When V(false), symlinks are not followed and attributes are set on the link itself (where supported).
-      - When V(true), attributes are set on the symlink target.
-      - Affects how O(mode), O(owner), and O(group) are applied.
-    type: bool
-    default: false
   directory_mode:
     description:
       - Permissions to set on directories that are created during the copy operation.

--- a/plugins/modules/file.py
+++ b/plugins/modules/file.py
@@ -15,12 +15,11 @@ author: Markus Weippert (@gekmihesg)
 extends_documentation_fragment:
   - community.openwrt.attributes
   - community.openwrt.attributes.files
+  - community.openwrt.file_common_arguments
 attributes:
   check_mode:
     support: full
   diff_mode:
-    support: full
-  safe_file_operations:
     support: full
 options:
   path:
@@ -62,22 +61,6 @@ options:
       - Only works with O(state=directory).
     type: bool
     default: false
-  follow:
-    description:
-      - Whether to follow symlinks.
-    type: bool
-  mode:
-    description:
-      - The permissions the resulting file or directory should have.
-    type: str
-  owner:
-    description:
-      - Name of the user that should own the file/directory.
-    type: str
-  group:
-    description:
-      - Name of the group that should own the file/directory.
-    type: str
   original_basename:
     description:
       - Original basename to use when O(path) is a directory.

--- a/plugins/modules/lineinfile.py
+++ b/plugins/modules/lineinfile.py
@@ -16,12 +16,11 @@ author: Markus Weippert (@gekmihesg)
 extends_documentation_fragment:
   - community.openwrt.attributes
   - community.openwrt.attributes.files
+  - community.openwrt.file_common_arguments
 attributes:
   check_mode:
     support: full
   diff_mode:
-    support: full
-  safe_file_operations:
     support: full
 options:
   path:
@@ -80,22 +79,6 @@ options:
       - Without this option, the task fails if the file does not exist.
     type: bool
     default: false
-  mode:
-    description:
-      - The permissions the resulting file should have.
-    type: str
-  owner:
-    description:
-      - Name of the user that should own the file.
-    type: str
-  group:
-    description:
-      - Name of the group that should own the file.
-    type: str
-  follow:
-    description:
-      - Whether to follow symlinks.
-    type: bool
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/sysctl.py
+++ b/plugins/modules/sysctl.py
@@ -14,14 +14,11 @@ description:
 author: Markus Weippert (@gekmihesg)
 extends_documentation_fragment:
   - community.openwrt.attributes
-  - community.openwrt.attributes.files
 attributes:
   check_mode:
     support: full
   diff_mode:
     support: none
-  safe_file_operations:
-    support: full
 options:
   name:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
More improvements in the documentation of common file args. Also removes attribute `safe_file_operations` from `sysctl`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/doc_fragments/attributes.py
plugins/doc_fragments/file_common_arguments.py
plugins/modules/copy.py
plugins/modules/file.py
plugins/modules/lineinfile.py
plugins/modules/sysctl.py
