### PR TITLE
command: enforce module's lack of support for check mode

### DIFF
--- a/plugins/modules/command.sh
+++ b/plugins/modules/command.sh
@@ -4,7 +4,8 @@
 # GNU General Public License v3.0 (see https://www.gnu.org/licenses/gpl-3.0.txt)
 
 init() {
-    export PARAMS="
+    SUPPORTS_CHECK_MODE=""  # effectively False
+    PARAMS="
         cmd=raw_params=_raw_params/str/r
         uses_shell=_uses_shell/bool//false
         chdir/str
@@ -12,17 +13,17 @@ init() {
         creates/str
         removes/str
     "
-    export RESPONSE_VARS="
+    RESPONSE_VARS="
         start end delta cmd
         stdout/str/a stderr/str/a rc/int/a
     "
     cmd=
-    export stdout=""
-    export stderr=""
-    export start=""
-    export end=""
-    export delta=""
-    export rc="0"
+    stdout=""
+    stderr=""
+    start=""
+    end=""
+    delta=""
+    rc="0"
     out="$(mktemp)" && err="$(mktemp)"
 }
 

--- a/tests/integration/targets/command/tasks/check-mode.yml
+++ b/tests/integration/targets/command/tasks/check-mode.yml
@@ -6,11 +6,8 @@
   check_mode: true
   register: check_out
 
-- name: Display check result
-  ansible.builtin.debug:
-    var: check_out
-
 - name: Ensure check produced no change
   ansible.builtin.assert:
     that:
-      - "check_out is changed"
+      - check_out is not changed
+      - check_out is skipped


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module does not support check mode, and though there is support for enforcing that in the wrapper library, `command` was not using it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
command
