### PR TITLE
[WIP] command: alternate way of not supporting check mode

### DIFF
--- a/plugins/modules/command.sh
+++ b/plugins/modules/command.sh
@@ -4,7 +4,6 @@
 # GNU General Public License v3.0 (see https://www.gnu.org/licenses/gpl-3.0.txt)
 
 init() {
-    SUPPORTS_CHECK_MODE=""  # effectively False
     PARAMS="
         cmd=raw_params=_raw_params/str/r
         uses_shell=_uses_shell/bool//false
@@ -28,6 +27,7 @@ init() {
 }
 
 validate() {
+    no_check_mode
     [ -n "$executable" ] || executable="/bin/sh"
 }
 

--- a/plugins/modules/wrapper.sh
+++ b/plugins/modules/wrapper.sh
@@ -200,6 +200,15 @@ _support_check_mode() {
     exit 0
 }
 
+no_check_mode() {
+    if [ -z "$_ansible_check_mode" ]; then
+        return 0
+    fi
+    SKIPPED="1"
+    MESSAGE="module does not support check mode"
+    exit 0
+}
+
 json_select_real() {
     local real_var
     json_get_var real_var "_$1"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As I did #78 it occurred to me that we might perform the check mode support enforcing more explicitly - instead of setting a variable, the module actually calls a function.

Not much change for the module:
- replace the variable with the function call, in `validate()` (after parameters are parsed)

Not much change for the wrapper:
- one variable less to keep track of
- the function testing check mode gets one notch simper (by not checking the var)

If we decide to adopt this, then the PR needs to be expanded to:
- wrapper:
  - remove `_support_check_mode()`
  - remove call to `_support_check_mode` (by the end of the wrapper)
- modules: ensure modules are using `no_check_mode` instead of setting `SUPPORTS_CHECK_MODE`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
wrapper
command