### PR TITLE
test(integration/copy): check behaviour when force=false

### DIFF
--- a/tests/integration/targets/copy/tasks/main.yml
+++ b/tests/integration/targets/copy/tasks/main.yml
@@ -60,7 +60,7 @@
   ansible.builtin.assert:
     that:
       - copy_out3c is not changed
-  ignore_errors: true # @TODO bug reported in #94
+      - copy_out3c is failed # @TODO bug reported in #94, it should not be failed
 
 - name: Create a dummy file on controller
   ansible.builtin.copy:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module `copy` has a default `force=true`, which suceeds regardless of the file existing and/or the content being different.

Prompted by #94 and #95, this PR ensures that the module copy is executed with `force=false`:
1. and the content has changed, it pops an error
2. and the content has NOT changed, the task `is not changed`

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
copy