### PR TITLE
test: bump OpenWrt to 25.12.0-rc3 (from rc2)

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -116,7 +116,7 @@ jobs:
       fail-fast: false
       matrix:
         openwrt: &openwrt-versions
-          - "25.12.0-rc2"
+          - "25.12.0-rc3"
           - "24.10.4"
           - "23.05.6"
         ansible: *ansible-versions

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The collection is currently tested against OpenWrt versions:
 - 22.03
 - 23.05
 - 24.10
-- 25.12-rc2
+- 25.12-rc3
 
 Keep in mind that OpenWrt, per its
 [Support Status policy](https://openwrt.org/docs/guide-developer/security#support_status),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
OpenWrt 25.12-rc3 has been released.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
