### PR TITLE
test(sanity/shellcheck): ignore POSIX compatibility codes

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -7,4 +7,4 @@ external-sources=true
 disable=SC2034
 
 # constructs are compatible with ash
-disable=SC3060,SC3057,SC3018,SC3003,SC3045
+disable=SC3000-SC4000

--- a/tests/utils/regen-shellcheck-ignores
+++ b/tests/utils/regen-shellcheck-ignores
@@ -19,7 +19,7 @@ from pathlib import Path
 
 
 class TitleParser(HTMLParser):
-    def __init__(self, body):
+    def __init__(self, body: str) -> None:
         super().__init__()
         self.in_title = False
         self.title_parts = []
@@ -38,14 +38,14 @@ class TitleParser(HTMLParser):
             self.title_parts.append(data)
 
     @property
-    def title(self):
+    def title(self) -> str:
         return html.unescape("".join(self.title_parts).strip())
 
 
 sc_desc_cache = {}
 
 
-def retrieve_sc_description(sc_code):
+def retrieve_sc_description(sc_code: str) -> str:
     try:
         return sc_desc_cache[sc_code]
     except KeyError:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The scripts in this collection are meant to run in OpenWrt, always using `ash` as shell, so POSIX compatibility is not a major concern.

This PR disables all checks in `shellcheck` related to POSIX compatibility - codes SC3000-SC4000.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
NA