### PR TITLE
test(integration): use ghcr.io as container registry

### DIFF
--- a/extensions/molecule/default/molecule.yml
+++ b/extensions/molecule/default/molecule.yml
@@ -6,7 +6,7 @@ driver:
   name: docker
 platforms:
   - name: openwrt_x86_64-${OPENWRT_VERSION:-24.10.4}
-    image: openwrt/rootfs:x86_64-${OPENWRT_VERSION:-24.10.4}
+    image: ghcr.io/openwrt/rootfs:x86_64-${OPENWRT_VERSION:-24.10.4}
     command: /sbin/init
     pre_build_image: true
 scenario:

--- a/extensions/molecule/integration_test/molecule.yml
+++ b/extensions/molecule/integration_test/molecule.yml
@@ -6,15 +6,15 @@ driver:
   name: docker
 platforms:
   - name: openwrt_x86_64-25.12.0-rc5
-    image: openwrt/rootfs:x86_64-25.12.0-rc5
+    image: ghcr.io/openwrt/rootfs:x86_64-25.12.0-rc5
     command: /sbin/init
     pre_build_image: true
   - name: openwrt_x86_64-24.10.4
-    image: openwrt/rootfs:x86_64-24.10.4
+    image: ghcr.io/openwrt/rootfs:x86_64-24.10.4
     command: /sbin/init
     pre_build_image: true
   - name: openwrt_x86_64-23.05.6
-    image: openwrt/rootfs:x86_64-23.05.6
+    image: ghcr.io/openwrt/rootfs:x86_64-23.05.6
     command: /sbin/init
     pre_build_image: true
 scenario:

--- a/extensions/molecule/role_init_install_recommended_false/molecule.yml
+++ b/extensions/molecule/role_init_install_recommended_false/molecule.yml
@@ -6,7 +6,7 @@ driver:
   name: docker
 platforms:
   - name: openwrt_x86_64-${OPENWRT_VERSION:-24.10.4}
-    image: openwrt/rootfs:x86_64-${OPENWRT_VERSION:-24.10.4}
+    image: ghcr.io/openwrt/rootfs:x86_64-${OPENWRT_VERSION:-24.10.4}
     command: /sbin/init
     pre_build_image: true
 scenario:

--- a/extensions/molecule/role_init_install_recommended_true/molecule.yml
+++ b/extensions/molecule/role_init_install_recommended_true/molecule.yml
@@ -6,7 +6,7 @@ driver:
   name: docker
 platforms:
   - name: openwrt_x86_64-${OPENWRT_VERSION:-24.10.4}
-    image: openwrt/rootfs:x86_64-${OPENWRT_VERSION:-24.10.4}
+    image: ghcr.io/openwrt/rootfs:x86_64-${OPENWRT_VERSION:-24.10.4}
     command: /sbin/init
     pre_build_image: true
 scenario:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As stated in https://github.com/openwrt/docker/blob/main/README.md the OpenWrt images are published to:

* docker.io (Docker)
* ghcr.io (GitHub)
* quay.io (RedHat)

By default the project was using docker.io, but on occasion, triggering multiple CI runs in this project, I bumped into docker.io's rate limits.

This PR changes the config to pull the images from ghcr.io instead:

* It should be faster for the CI runs (within the same infrastructure)
* Less likely to bump into rate limits

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
extensions/molecule/default/molecule.yml
extensions/molecule/integration_test/molecule.yml
extensions/molecule/role_init_install_recommended_false/molecule.yml
extensions/molecule/role_init_install_recommended_true/molecule.yml
