### PR TITLE
test(integration/service): delay before checking service running status

### DIFF
--- a/tests/integration/targets/service/tasks/main.yml
+++ b/tests/integration/targets/service/tasks/main.yml
@@ -39,15 +39,13 @@
     name: cron
     state: started
 
-- name: Pause for 10 seconds
-  ansible.builtin.pause:
-    seconds: 10
-
 - name: Check cron running
   community.openwrt.command:
     cmd: service cron running
   changed_when: false
   failed_when: cron_running.rc != 0
+  retries: 15
+  delay: 2
   register: cron_running
 
 - name: Stop cron service
@@ -55,15 +53,13 @@
     name: cron
     state: stopped
 
-- name: Pause for 10 seconds
-  ansible.builtin.pause:
-    seconds: 10
-
 - name: Check cron running
   community.openwrt.command:
     cmd: service cron running
   changed_when: false
   failed_when: cron_state.rc == 0
+  retries: 15
+  delay: 2
   register: cron_state
 
 - name: Clean up - remove crontab file


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
~~Como pode ser visto no log de CI~~ As can be seen in the CI logs:
https://github.com/ansible-collections/community.openwrt/actions/runs/22273226064/job/64431124253?pr=152

```
TASK [community.openwrt./root/ansible_collections/community/openwrt/tests/integration/targets/service : Stop cron service] ***
changed: [openwrt_x86_64-23.05.6] => {"changed": true, "name": "cron", "state": "stopped"}
changed: [openwrt_x86_64-24.10.4] => {"changed": true, "name": "cron", "state": "stopped"}
changed: [openwrt_x86_64-25.12.0-rc5] => {"changed": true, "name": "cron", "state": "stopped"}

TASK [community.openwrt./root/ansible_collections/community/openwrt/tests/integration/targets/service : Check cron running] ***
fatal: [openwrt_x86_64-24.10.4]: FAILED! => {"changed": false, "cmd": "service cron running", "delta": "0:00:00.000000", "end": "2026-02-22 08:04:10.000000", "failed_when_result": true, "rc": 0, "start": "2026-02-22 08:04:10.000000", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
ok: [openwrt_x86_64-23.05.6] => {"changed": false, "cmd": "service cron running", "delta": "0:00:00.000000", "end": "2026-02-22 08:04:10.000000", "failed_when_result": false, "msg": "non-zero return code", "rc": 123, "start": "2026-02-22 08:04:10.000000", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
ok: [openwrt_x86_64-25.12.0-rc5] => {"changed": false, "cmd": "service cron running", "delta": "0:00:00.000000", "end": "2026-02-22 08:04:10.000000", "failed_when_result": false, "msg": "non-zero return code", "rc": 123, "start": "2026-02-22 08:04:10.000000", "stderr": "", "stderr_lines": [], "stdout": "", "stdout_lines": []}
```

The test failed with `"failed_when_result": true`. The relevant tasks in that test are:

```yaml
- name: Stop cron service
  community.openwrt.service:
    name: cron
    state: stopped

- name: Check cron running
  community.openwrt.command:
    cmd: service cron running
  changed_when: false
  failed_when: cron_state.rc == 0
  register: cron_state
```

Meaning that `cron_state.rc` was indeed `0` when it should be something else (the succeeding cases have `rc=123`). When `service cron running` returns `0`, that means the service is still running. This is likely caused by the fact that `service` issues the stop command assynchronously, without waiting for the service to actually stop

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
tests/integration/targets/service/tasks/main.yml