### PR TITLE
test(integration/service): increase delay between checks

### DIFF
--- a/tests/integration/targets/service/tasks/main.yml
+++ b/tests/integration/targets/service/tasks/main.yml
@@ -45,7 +45,7 @@
   changed_when: false
   failed_when: cron_running.rc != 0
   retries: 15
-  delay: 2
+  delay: 3
   register: cron_running
 
 - name: Stop cron service
@@ -59,7 +59,7 @@
   changed_when: false
   failed_when: cron_state.rc == 0
   retries: 15
-  delay: 2
+  delay: 3
   register: cron_state
 
 - name: Clean up - remove crontab file


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
During the release of 1.1.0, a test failed even with the retries covering a period of 30 seconds, so bumping the delay from 2 seconds to 3, leading to a retry period of 45 seconds. Hopefully that should be enough.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Test Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
service