### PR TITLE
fix(modules/setup): filter out wifi secrets

### DIFF
--- a/changelogs/fragments/211-setup-wifi-password-leak.yml
+++ b/changelogs/fragments/211-setup-wifi-password-leak.yml
@@ -1,4 +1,5 @@
 breaking_changes:
-  - setup - sensitive wireless credentials are now redacted from the ``openwrt_wireless`` facts
+  - setup - sensitive wireless credentials are now redacted from the ``openwrt_wireless`` facts by default
+    unless ``expose_secrets=true`` option is passed
     (https://github.com/ansible-collections/community.openwrt/issues/38,
     https://github.com/ansible-collections/community.openwrt/pull/211).

--- a/changelogs/fragments/211-setup-wifi-password-leak.yml
+++ b/changelogs/fragments/211-setup-wifi-password-leak.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+  - setup - sensitive wireless credentials are now redacted from the ``openwrt_wireless`` facts
+    (https://github.com/ansible-collections/community.openwrt/issues/38,
+    https://github.com/ansible-collections/community.openwrt/pull/211).

--- a/plugins/action/setup.py
+++ b/plugins/action/setup.py
@@ -22,6 +22,8 @@ _WIRELESS_SENSITIVE_KEYS = frozenset(
         "priv_key2_pwd",  # EAP private key passphrases
         "private_key_passwd",  # hostapd server private key passphrase
         "multi_ap_backhaul_key",  # Multi-AP backhaul key
+        "r0kh",  # 802.11r roaming key holder 0 (contains shared keys)
+        "r1kh",  # 802.11r roaming key holder 1 (contains shared keys)
     }
 )
 

--- a/plugins/action/setup.py
+++ b/plugins/action/setup.py
@@ -6,13 +6,20 @@ from __future__ import annotations
 
 from ansible_collections.community.openwrt.plugins.plugin_utils.openwrt_action import OpenwrtActionBase
 
-_WIRELESS_SENSITIVE_KEYS = frozenset({
-    "key", "key1", "key2", "key3", "key4",  # WPA PSK / WEP
-    "sae_password",                          # WPA3-SAE
-    "password",                              # EAP user password
-    "auth_secret", "acct_secret",            # RADIUS shared secrets
-    "priv_key_pwd",                          # EAP private key password
-})
+_WIRELESS_SENSITIVE_KEYS = frozenset(
+    {
+        "key",
+        "key1",
+        "key2",
+        "key3",
+        "key4",  # WPA PSK / WEP
+        "sae_password",  # WPA3-SAE
+        "password",  # EAP user password
+        "auth_secret",
+        "acct_secret",  # RADIUS shared secrets
+        "priv_key_pwd",  # EAP private key password
+    }
+)
 
 
 def _redact_wireless(obj):

--- a/plugins/action/setup.py
+++ b/plugins/action/setup.py
@@ -6,7 +6,13 @@ from __future__ import annotations
 
 from ansible_collections.community.openwrt.plugins.plugin_utils.openwrt_action import OpenwrtActionBase
 
-_WIRELESS_SENSITIVE_KEYS = frozenset({"key", "password", "psk"})
+_WIRELESS_SENSITIVE_KEYS = frozenset({
+    "key", "key1", "key2", "key3", "key4",  # WPA PSK / WEP
+    "sae_password",                          # WPA3-SAE
+    "password",                              # EAP user password
+    "auth_secret", "acct_secret",            # RADIUS shared secrets
+    "priv_key_pwd",                          # EAP private key password
+})
 
 
 def _redact_wireless(obj):

--- a/plugins/action/setup.py
+++ b/plugins/action/setup.py
@@ -6,6 +6,23 @@ from __future__ import annotations
 
 from ansible_collections.community.openwrt.plugins.plugin_utils.openwrt_action import OpenwrtActionBase
 
+_WIRELESS_SENSITIVE_KEYS = frozenset({"key", "password", "psk"})
+
+
+def _redact_wireless(obj):
+    if isinstance(obj, dict):
+        return {k: _redact_wireless(v) for k, v in obj.items() if k not in _WIRELESS_SENSITIVE_KEYS}
+    if isinstance(obj, list):
+        return [_redact_wireless(item) for item in obj]
+    return obj
+
 
 class ActionModule(OpenwrtActionBase):
-    pass
+    def run(self, tmp=None, task_vars=None):
+        result = super().run(tmp, task_vars)
+
+        ansible_facts = result.get("ansible_facts", {})
+        if "openwrt_wireless" in ansible_facts:
+            ansible_facts["openwrt_wireless"] = _redact_wireless(ansible_facts["openwrt_wireless"])
+
+        return result

--- a/plugins/action/setup.py
+++ b/plugins/action/setup.py
@@ -17,7 +17,11 @@ _WIRELESS_SENSITIVE_KEYS = frozenset(
         "password",  # EAP user password
         "auth_secret",
         "acct_secret",  # RADIUS shared secrets
-        "priv_key_pwd",  # EAP private key password
+        "dae_secret",  # RADIUS DAE shared secret
+        "priv_key_pwd",
+        "priv_key2_pwd",  # EAP private key passphrases
+        "private_key_passwd",  # hostapd server private key passphrase
+        "multi_ap_backhaul_key",  # Multi-AP backhaul key
     }
 )
 
@@ -32,10 +36,19 @@ def _redact_wireless(obj):
 
 class ActionModule(OpenwrtActionBase):
     def run(self, tmp=None, task_vars=None):
+        expose_secrets = self._task.args.get("expose_secrets", False)
+
+        # get_ds() returns the raw parsed task dict, which only contains keys the user
+        # explicitly wrote — unlike task_vars, which has no_log already resolved to its
+        # default (False) and cannot distinguish "set" from "not set".
+        if expose_secrets and "no_log" not in (self._task.get_ds() or {}):
+            return {"failed": True, "msg": "expose_secrets=true requires an explicit no_log setting on the task"}
+
         result = super().run(tmp, task_vars)
 
-        ansible_facts = result.get("ansible_facts", {})
-        if "openwrt_wireless" in ansible_facts:
-            ansible_facts["openwrt_wireless"] = _redact_wireless(ansible_facts["openwrt_wireless"])
+        if not expose_secrets:
+            ansible_facts = result.get("ansible_facts", {})
+            if "openwrt_wireless" in ansible_facts:
+                ansible_facts["openwrt_wireless"] = _redact_wireless(ansible_facts["openwrt_wireless"])
 
         return result

--- a/plugins/modules/setup.py
+++ b/plugins/modules/setup.py
@@ -18,7 +18,18 @@ extends_documentation_fragment:
   - community.openwrt.attributes
   - community.openwrt.attributes.facts
   - community.openwrt.attributes.facts_module
-options: {}
+options:
+  expose_secrets:
+    description:
+      - When V(true), sensitive wireless credentials are included in the C(openwrt_wireless) fact.
+      - By default these values are redacted to prevent accidental leakage in logs or task output.
+      - When set to V(true), the task must also have an explicit C(no_log) setting (V(true) or V(false));
+        omitting C(no_log) is treated as an error to ensure a conscious decision is made about logging.
+      - See R(OpenWrt wireless configuration,https://openwrt.org/docs/guide-user/network/wifi/basic) for the full list
+        of wireless options; the ones treated as secrets by this module are documented in the notes below.
+    type: bool
+    default: false
+    version_added: "1.3.0"
 notes:
   - This module gathers OpenWrt-specific facts including C(ubus) data for network interfaces, devices, services, and
     system information.
@@ -35,8 +46,15 @@ notes:
   - Conversely, C(ansible_date_time.tz_dst) is obtained in the standard module through an internal Python function, so
     in order to provide compatibility, that fact is returned by M(community.openwrt.setup) with the exact same value as
     C(ansible_date_time.tz).
-  - Sensitive values such as wireless passwords and credentials (C(key), C(key1)–C(key4), C(sae_password),
-    C(password), C(auth_secret), C(acct_secret), C(priv_key_pwd)) are redacted from the C(openwrt_wireless) facts.
+  - Unless O(expose_secrets=true) is set, the following wireless credential fields are redacted from
+    C(openwrt_wireless) facts - C(key), C(key1)–C(key4) (WPA PSK / WEP keys); C(sae_password) (WPA3-SAE);
+    C(password) (EAP); C(auth_secret), C(acct_secret), C(dae_secret) (RADIUS shared secrets);
+    C(priv_key_pwd), C(priv_key2_pwd), C(private_key_passwd) (private key passphrases);
+    C(multi_ap_backhaul_key) (Multi-AP backhaul).
+seealso:
+  - name: OpenWrt wireless configuration reference
+    description: UCI options for wireless interfaces, including all security and encryption parameters.
+    link: https://openwrt.org/docs/guide-user/network/wifi/basic
 """
 
 EXAMPLES = r"""
@@ -46,6 +64,11 @@ EXAMPLES = r"""
 - name: Show distribution version
   ansible.builtin.debug:
     msg: "{{ ansible_distribution_version }}"
+
+- name: Gather facts including wireless credentials (handle with care)
+  community.openwrt.setup:
+    expose_secrets: true
+  no_log: true
 """
 
 RETURN = r"""
@@ -110,7 +133,7 @@ ansible_facts:
       returned: when available
       type: dict
     openwrt_wireless:
-      description: Wireless status from C(ubus).
+      description: Wireless status from C(ubus). Sensitive credential fields are redacted unless O(expose_secrets=true).
       returned: when available
       type: dict
     openwrt_interfaces:

--- a/plugins/modules/setup.py
+++ b/plugins/modules/setup.py
@@ -35,7 +35,8 @@ notes:
   - Conversely, C(ansible_date_time.tz_dst) is obtained in the standard module through an internal Python function, so
     in order to provide compatibility, that fact is returned by M(community.openwrt.setup) with the exact same value as
     C(ansible_date_time.tz).
-  - Sensitive values such as wireless passwords are redacted from the facts.
+  - Sensitive values such as wireless passwords and credentials (C(key), C(key1)–C(key4), C(sae_password),
+    C(password), C(auth_secret), C(acct_secret), C(priv_key_pwd)) are redacted from the C(openwrt_wireless) facts.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/setup.py
+++ b/plugins/modules/setup.py
@@ -25,7 +25,7 @@ options:
       - By default these values are redacted to prevent accidental leakage in logs or task output.
       - When set to V(true), the task must also have an explicit C(no_log) setting (V(true) or V(false));
         omitting C(no_log) is treated as an error to ensure a conscious decision is made about logging.
-      - See R(OpenWrt wireless configuration,https://openwrt.org/docs/guide-user/network/wifi/basic) for the full list
+      - See L(OpenWrt wireless configuration, https://openwrt.org/docs/guide-user/network/wifi/basic) for the full list
         of wireless options; the ones treated as secrets by this module are documented in the notes below.
     type: bool
     default: false

--- a/plugins/modules/setup.py
+++ b/plugins/modules/setup.py
@@ -35,6 +35,7 @@ notes:
   - Conversely, C(ansible_date_time.tz_dst) is obtained in the standard module through an internal Python function, so
     in order to provide compatibility, that fact is returned by M(community.openwrt.setup) with the exact same value as
     C(ansible_date_time.tz).
+  - Sensitive values such as wireless passwords are redacted from the facts.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/setup.py
+++ b/plugins/modules/setup.py
@@ -50,7 +50,7 @@ notes:
     C(openwrt_wireless) facts - C(key), C(key1)–C(key4) (WPA PSK / WEP keys); C(sae_password) (WPA3-SAE);
     C(password) (EAP); C(auth_secret), C(acct_secret), C(dae_secret) (RADIUS shared secrets);
     C(priv_key_pwd), C(priv_key2_pwd), C(private_key_passwd) (private key passphrases);
-    C(multi_ap_backhaul_key) (Multi-AP backhaul).
+    C(multi_ap_backhaul_key) (Multi-AP backhaul); C(r0kh), C(r1kh) (802.11r roaming key holders).
 seealso:
   - name: OpenWrt wireless configuration reference
     description: UCI options for wireless interfaces, including all security and encryption parameters.

--- a/tests/unit/plugins/action/test_setup.py
+++ b/tests/unit/plugins/action/test_setup.py
@@ -8,7 +8,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from ansible_collections.community.openwrt.plugins.action.setup import ActionModule, _redact_wireless
+from ansible_collections.community.openwrt.plugins.action.setup import (
+    _WIRELESS_SENSITIVE_KEYS,
+    ActionModule,
+    _redact_wireless,
+)
 
 
 def _make_action():
@@ -17,6 +21,7 @@ def _make_action():
     obj._task.action = "community.openwrt.setup"
     obj._task.async_val = 0
     obj._task.args = {}
+    obj._task.get_ds.return_value = {}
     obj._connection = MagicMock()
     obj._connection._shell.join_path = MagicMock(return_value="/tmp/remote/setup.sh")
     obj._templar = MagicMock()
@@ -40,6 +45,7 @@ WIRELESS_WITH_SECRETS = {
                     "password": "guest-pass",
                     "auth_secret": "rad1us",
                     "acct_secret": "rad1us2",
+                    "dae_secret": "dae-s3cr3t",
                 }
             },
         ]
@@ -56,26 +62,30 @@ WIRELESS_WITH_SECRETS = {
                     "key4": "wep4",
                 }
             },
-            {"config": {"mode": "ap", "ssid": "Corp", "priv_key_pwd": "certpass"}},
+            {
+                "config": {
+                    "mode": "ap",
+                    "ssid": "Corp",
+                    "priv_key_pwd": "certpass",
+                    "priv_key2_pwd": "certpass2",
+                    "private_key_passwd": "srvkeypass",
+                    "multi_ap_backhaul_key": "backhaul-s3cr3t",
+                }
+            },
         ]
     },
 }
 
-SENSITIVE_KEYS = [
-    "key",
-    "key1",
-    "key2",
-    "key3",
-    "key4",
-    "sae_password",
-    "password",
-    "auth_secret",
-    "acct_secret",
-    "priv_key_pwd",
-]
+
+def test_task_get_ds_api_exists():
+    """Canary: get_ds() is an internal Ansible API we rely on to detect explicit no_log.
+    If this fails, the Ansible core Task class has changed and the no_log check needs revisiting."""
+    from ansible.playbook.base import Base
+
+    assert callable(getattr(Base, "get_ds", None))
 
 
-@pytest.mark.parametrize("sensitive_key", SENSITIVE_KEYS)
+@pytest.mark.parametrize("sensitive_key", sorted(_WIRELESS_SENSITIVE_KEYS))
 def test_redact_wireless_removes_sensitive_keys(sensitive_key):
     result = _redact_wireless(WIRELESS_WITH_SECRETS)
     configs = [iface["config"] for radio in result.values() for iface in radio["interfaces"]]
@@ -105,7 +115,33 @@ def test_run_redacts_wireless_facts(mocker):
         for radio in result["ansible_facts"]["openwrt_wireless"].values()
         for iface in radio["interfaces"]
     ]
-    assert all("key" not in cfg and "password" not in cfg and "psk" not in cfg for cfg in configs)
+    assert all(k not in cfg for cfg in configs for k in _WIRELESS_SENSITIVE_KEYS)
+
+
+def test_run_expose_secrets_requires_explicit_no_log(mocker):
+    action = _make_action()
+    action._task.args = {"expose_secrets": True}
+    action._task.get_ds.return_value = {"expose_secrets": True}  # no_log absent
+    mocker.patch(
+        "ansible_collections.community.openwrt.plugins.plugin_utils.openwrt_action.OpenwrtActionBase.run",
+        return_value={"changed": False, "ansible_facts": {"openwrt_wireless": WIRELESS_WITH_SECRETS}},
+    )
+    result = action.run(task_vars={})
+    assert result["failed"] is True
+    assert "no_log" in result["msg"]
+    assert "ansible_facts" not in result
+
+
+def test_run_expose_secrets_preserves_wireless_facts(mocker):
+    action = _make_action()
+    action._task.args = {"expose_secrets": True}
+    action._task.get_ds.return_value = {"expose_secrets": True, "no_log": False}
+    mocker.patch(
+        "ansible_collections.community.openwrt.plugins.plugin_utils.openwrt_action.OpenwrtActionBase.run",
+        return_value={"changed": False, "ansible_facts": {"openwrt_wireless": WIRELESS_WITH_SECRETS}},
+    )
+    result = action.run(task_vars={})
+    assert result["ansible_facts"]["openwrt_wireless"] == WIRELESS_WITH_SECRETS
 
 
 def test_run_without_wireless_facts(mocker):

--- a/tests/unit/plugins/action/test_setup.py
+++ b/tests/unit/plugins/action/test_setup.py
@@ -70,6 +70,8 @@ WIRELESS_WITH_SECRETS = {
                     "priv_key2_pwd": "certpass2",
                     "private_key_passwd": "srvkeypass",
                     "multi_ap_backhaul_key": "backhaul-s3cr3t",
+                    "r0kh": "aa:bb:cc:dd:ee:ff r0kh-id s3cr3t",
+                    "r1kh": "aa:bb:cc:dd:ee:ff aa:bb:cc:dd:ee:ff s3cr3t",
                 }
             },
         ]

--- a/tests/unit/plugins/action/test_setup.py
+++ b/tests/unit/plugins/action/test_setup.py
@@ -8,8 +8,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from ansible_collections.community.openwrt.plugins.action.setup import ActionModule
-from ansible_collections.community.openwrt.plugins.action.setup import _redact_wireless
+from ansible_collections.community.openwrt.plugins.action.setup import ActionModule, _redact_wireless
 
 
 def _make_action():
@@ -34,18 +33,46 @@ WIRELESS_WITH_SECRETS = {
     "radio0": {
         "interfaces": [
             {"config": {"mode": "ap", "ssid": "MyNet", "key": "s3cr3t", "sae_password": "sae-s3cr3t"}},
-            {"config": {"mode": "ap", "ssid": "Guest", "password": "guest-pass", "auth_secret": "rad1us", "acct_secret": "rad1us2"}},
+            {
+                "config": {
+                    "mode": "ap",
+                    "ssid": "Guest",
+                    "password": "guest-pass",
+                    "auth_secret": "rad1us",
+                    "acct_secret": "rad1us2",
+                }
+            },
         ]
     },
     "radio1": {
         "interfaces": [
-            {"config": {"mode": "sta", "ssid": "Upstream", "key1": "wep1", "key2": "wep2", "key3": "wep3", "key4": "wep4"}},
+            {
+                "config": {
+                    "mode": "sta",
+                    "ssid": "Upstream",
+                    "key1": "wep1",
+                    "key2": "wep2",
+                    "key3": "wep3",
+                    "key4": "wep4",
+                }
+            },
             {"config": {"mode": "ap", "ssid": "Corp", "priv_key_pwd": "certpass"}},
         ]
     },
 }
 
-SENSITIVE_KEYS = ["key", "key1", "key2", "key3", "key4", "sae_password", "password", "auth_secret", "acct_secret", "priv_key_pwd"]
+SENSITIVE_KEYS = [
+    "key",
+    "key1",
+    "key2",
+    "key3",
+    "key4",
+    "sae_password",
+    "password",
+    "auth_secret",
+    "acct_secret",
+    "priv_key_pwd",
+]
 
 
 @pytest.mark.parametrize("sensitive_key", SENSITIVE_KEYS)

--- a/tests/unit/plugins/action/test_setup.py
+++ b/tests/unit/plugins/action/test_setup.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2026, Alexei Znamensky (@russoz)
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ansible_collections.community.openwrt.plugins.action.setup import ActionModule
+from ansible_collections.community.openwrt.plugins.action.setup import _redact_wireless
+
+
+def _make_action():
+    obj = object.__new__(ActionModule)
+    obj._task = MagicMock()
+    obj._task.action = "community.openwrt.setup"
+    obj._task.async_val = 0
+    obj._task.args = {}
+    obj._connection = MagicMock()
+    obj._connection._shell.join_path = MagicMock(return_value="/tmp/remote/setup.sh")
+    obj._templar = MagicMock()
+    obj._loader = MagicMock()
+    obj._play_context = MagicMock()
+    obj._shared_loader_obj = MagicMock()
+    obj._make_tmp_path = MagicMock(return_value="/tmp/remote")
+    obj._transfer_file = MagicMock()
+    obj._fixup_perms2 = MagicMock()
+    return obj
+
+
+WIRELESS_WITH_SECRETS = {
+    "radio0": {
+        "interfaces": [
+            {"config": {"mode": "ap", "ssid": "MyNet", "key": "s3cr3t", "psk": "also-secret"}},
+            {"config": {"mode": "ap", "ssid": "Guest", "password": "guest-pass"}},
+        ]
+    },
+    "radio1": {
+        "interfaces": [
+            {"config": {"mode": "sta", "ssid": "Upstream", "key": "upstream-key"}},
+        ]
+    },
+}
+
+
+@pytest.mark.parametrize("sensitive_key", ["key", "password", "psk"])
+def test_redact_wireless_removes_sensitive_keys(sensitive_key):
+    result = _redact_wireless(WIRELESS_WITH_SECRETS)
+    configs = [iface["config"] for radio in result.values() for iface in radio["interfaces"]]
+    assert all(sensitive_key not in cfg for cfg in configs)
+
+
+def test_redact_wireless_preserves_other_keys():
+    result = _redact_wireless(WIRELESS_WITH_SECRETS)
+    configs = [iface["config"] for radio in result.values() for iface in radio["interfaces"]]
+    assert all("ssid" in cfg for cfg in configs)
+    assert all("mode" in cfg for cfg in configs)
+
+
+def test_redact_wireless_handles_empty():
+    assert _redact_wireless({}) == {}
+
+
+def test_run_redacts_wireless_facts(mocker):
+    action = _make_action()
+    mocker.patch(
+        "ansible_collections.community.openwrt.plugins.plugin_utils.openwrt_action.OpenwrtActionBase.run",
+        return_value={"changed": False, "ansible_facts": {"openwrt_wireless": WIRELESS_WITH_SECRETS}},
+    )
+    result = action.run(task_vars={})
+    configs = [
+        iface["config"]
+        for radio in result["ansible_facts"]["openwrt_wireless"].values()
+        for iface in radio["interfaces"]
+    ]
+    assert all("key" not in cfg and "password" not in cfg and "psk" not in cfg for cfg in configs)
+
+
+def test_run_without_wireless_facts(mocker):
+    action = _make_action()
+    mocker.patch(
+        "ansible_collections.community.openwrt.plugins.plugin_utils.openwrt_action.OpenwrtActionBase.run",
+        return_value={"changed": False, "ansible_facts": {"ansible_hostname": "router"}},
+    )
+    result = action.run(task_vars={})
+    assert "openwrt_wireless" not in result["ansible_facts"]

--- a/tests/unit/plugins/action/test_setup.py
+++ b/tests/unit/plugins/action/test_setup.py
@@ -33,19 +33,22 @@ def _make_action():
 WIRELESS_WITH_SECRETS = {
     "radio0": {
         "interfaces": [
-            {"config": {"mode": "ap", "ssid": "MyNet", "key": "s3cr3t", "psk": "also-secret"}},
-            {"config": {"mode": "ap", "ssid": "Guest", "password": "guest-pass"}},
+            {"config": {"mode": "ap", "ssid": "MyNet", "key": "s3cr3t", "sae_password": "sae-s3cr3t"}},
+            {"config": {"mode": "ap", "ssid": "Guest", "password": "guest-pass", "auth_secret": "rad1us", "acct_secret": "rad1us2"}},
         ]
     },
     "radio1": {
         "interfaces": [
-            {"config": {"mode": "sta", "ssid": "Upstream", "key": "upstream-key"}},
+            {"config": {"mode": "sta", "ssid": "Upstream", "key1": "wep1", "key2": "wep2", "key3": "wep3", "key4": "wep4"}},
+            {"config": {"mode": "ap", "ssid": "Corp", "priv_key_pwd": "certpass"}},
         ]
     },
 }
 
+SENSITIVE_KEYS = ["key", "key1", "key2", "key3", "key4", "sae_password", "password", "auth_secret", "acct_secret", "priv_key_pwd"]
 
-@pytest.mark.parametrize("sensitive_key", ["key", "password", "psk"])
+
+@pytest.mark.parametrize("sensitive_key", SENSITIVE_KEYS)
 def test_redact_wireless_removes_sensitive_keys(sensitive_key):
     result = _redact_wireless(WIRELESS_WITH_SECRETS)
     configs = [iface["config"] for radio in result.values() for iface in radio["interfaces"]]


### PR DESCRIPTION
## SUMMARY
<!-- Describe the change below, including rationale and design decisions -->
Filter out secrets from the wifi configuration in the output of `community.openwrt.setup`.

<!-- If you are fixing an existing issue, uncomment the line below and adjust the number -->
Fixes #38 

<!-- See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->


<!-- Please do not forget to include a changelog fragment:
     https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
     No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
     Read about more details in CONTRIBUTING.md. -->

## ISSUE TYPE
<!-- Pick one or more below and delete the rest.
     'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request

## COMPONENT NAME
<!-- This section will be filled automatically with the files changed in this PR.
     In case you want to do it, remove the start/end comments and
     write the SHORT NAME of the modules, plugins, tasks or features below. -->
<!-- component-name-start -->
plugins/action/setup.py
plugins/modules/setup.py
<!-- component-name-end -->

