### PR TITLE
test(sanity/shellcheck): ignore code SC2154

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -10,5 +10,8 @@ external-sources=true
 # unused variables - PARAMS is picked up on this, that will always happen in all modules
 disable=SC2034
 
+# var is referenced but not assigned - module parameters are picked up in all modules
+disable=SC2154
+
 # constructs are compatible with ash
 disable=SC3000-SC4000

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -34,57 +34,44 @@ plugins/modules/uci.sh shebang
 plugins/modules/uci.sh validate-modules:invalid-extension
 plugins/modules/wrapper.sh shebang
 plugins/modules/wrapper.sh validate-modules:invalid-extension
-plugins/modules/apk.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/apk.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2016   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2059   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2091   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/group.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2016   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/nohup.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/ping.sh shellcheck:SC2319   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/service.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2012   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2155   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/slurp.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2005   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2162   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/tempfile.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC1087   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2012   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2119   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2120   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2155   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
+plugins/modules/apk.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/copy.sh shellcheck:SC2016   # Expressions don't expand in single quotes, use double quotes for that - https://www.shellcheck.net/wiki/SC2016
+plugins/modules/copy.sh shellcheck:SC2059   # Don't use variables in the `printf` format string. Use `printf "..%s.." "$foo"` - https://www.shellcheck.net/wiki/SC2059
+plugins/modules/copy.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/copy.sh shellcheck:SC2091   # Remove surrounding `$()` to avoid executing output (or use `eval` if intentional) - https://www.shellcheck.net/wiki/SC2091
+plugins/modules/copy.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/file.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/file.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/file.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/file.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/lineinfile.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/lineinfile.sh shellcheck:SC2016   # Expressions don't expand in single quotes, use double quotes for that - https://www.shellcheck.net/wiki/SC2016
+plugins/modules/lineinfile.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/opkg.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/opkg.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/ping.sh shellcheck:SC2319   # This `$?` refers to a condition, not a command. Assign to a variable to avoid it being overwritten - https://www.shellcheck.net/wiki/SC2319
+plugins/modules/setup.sh shellcheck:SC2012   # Use `find` instead of `ls` to better handle non-alphanumeric filenames - https://www.shellcheck.net/wiki/SC2012
+plugins/modules/setup.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/setup.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/setup.sh shellcheck:SC2155   # Declare and assign separately to avoid masking return values - https://www.shellcheck.net/wiki/SC2155
+plugins/modules/stat.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/stat.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/stat.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/sysctl.sh shellcheck:SC2005   # ShellCheck: SC2005 – - https://www.shellcheck.net/wiki/SC2005
+plugins/modules/sysctl.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/sysctl.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/sysctl.sh shellcheck:SC2162   # `read` without `-r` will mangle backslashes - https://www.shellcheck.net/wiki/SC2162
+plugins/modules/sysctl.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/uci.sh shellcheck:SC1087   # Use braces when expanding arrays, e.g. `${array[idx]}` (or `${var}[..` to quiet) - https://www.shellcheck.net/wiki/SC1087
+plugins/modules/uci.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/uci.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/uci.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/uci.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/wrapper.sh shellcheck:SC2012   # Use `find` instead of `ls` to better handle non-alphanumeric filenames - https://www.shellcheck.net/wiki/SC2012
+plugins/modules/wrapper.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/wrapper.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/wrapper.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/wrapper.sh shellcheck:SC2119   # Use `foo "$@"` if function's `$1` should mean script's `$1` - https://www.shellcheck.net/wiki/SC2119
+plugins/modules/wrapper.sh shellcheck:SC2120   # foo references arguments, but none are ever passed - https://www.shellcheck.net/wiki/SC2120
+plugins/modules/wrapper.sh shellcheck:SC2155   # Declare and assign separately to avoid masking return values - https://www.shellcheck.net/wiki/SC2155
+plugins/modules/wrapper.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -34,57 +34,44 @@ plugins/modules/uci.sh shebang
 plugins/modules/uci.sh validate-modules:invalid-extension
 plugins/modules/wrapper.sh shebang
 plugins/modules/wrapper.sh validate-modules:invalid-extension
-plugins/modules/apk.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/apk.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2016   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2059   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2091   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/group.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2016   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/nohup.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/ping.sh shellcheck:SC2319   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/service.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2012   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2155   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/slurp.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2005   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2162   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/tempfile.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC1087   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2012   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2119   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2120   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2155   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
+plugins/modules/apk.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/copy.sh shellcheck:SC2016   # Expressions don't expand in single quotes, use double quotes for that - https://www.shellcheck.net/wiki/SC2016
+plugins/modules/copy.sh shellcheck:SC2059   # Don't use variables in the `printf` format string. Use `printf "..%s.." "$foo"` - https://www.shellcheck.net/wiki/SC2059
+plugins/modules/copy.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/copy.sh shellcheck:SC2091   # Remove surrounding `$()` to avoid executing output (or use `eval` if intentional) - https://www.shellcheck.net/wiki/SC2091
+plugins/modules/copy.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/file.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/file.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/file.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/file.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/lineinfile.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/lineinfile.sh shellcheck:SC2016   # Expressions don't expand in single quotes, use double quotes for that - https://www.shellcheck.net/wiki/SC2016
+plugins/modules/lineinfile.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/opkg.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/opkg.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/ping.sh shellcheck:SC2319   # This `$?` refers to a condition, not a command. Assign to a variable to avoid it being overwritten - https://www.shellcheck.net/wiki/SC2319
+plugins/modules/setup.sh shellcheck:SC2012   # Use `find` instead of `ls` to better handle non-alphanumeric filenames - https://www.shellcheck.net/wiki/SC2012
+plugins/modules/setup.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/setup.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/setup.sh shellcheck:SC2155   # Declare and assign separately to avoid masking return values - https://www.shellcheck.net/wiki/SC2155
+plugins/modules/stat.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/stat.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/stat.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/sysctl.sh shellcheck:SC2005   # ShellCheck: SC2005 – - https://www.shellcheck.net/wiki/SC2005
+plugins/modules/sysctl.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/sysctl.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/sysctl.sh shellcheck:SC2162   # `read` without `-r` will mangle backslashes - https://www.shellcheck.net/wiki/SC2162
+plugins/modules/sysctl.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/uci.sh shellcheck:SC1087   # Use braces when expanding arrays, e.g. `${array[idx]}` (or `${var}[..` to quiet) - https://www.shellcheck.net/wiki/SC1087
+plugins/modules/uci.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/uci.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/uci.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/uci.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/wrapper.sh shellcheck:SC2012   # Use `find` instead of `ls` to better handle non-alphanumeric filenames - https://www.shellcheck.net/wiki/SC2012
+plugins/modules/wrapper.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/wrapper.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/wrapper.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/wrapper.sh shellcheck:SC2119   # Use `foo "$@"` if function's `$1` should mean script's `$1` - https://www.shellcheck.net/wiki/SC2119
+plugins/modules/wrapper.sh shellcheck:SC2120   # foo references arguments, but none are ever passed - https://www.shellcheck.net/wiki/SC2120
+plugins/modules/wrapper.sh shellcheck:SC2155   # Declare and assign separately to avoid masking return values - https://www.shellcheck.net/wiki/SC2155
+plugins/modules/wrapper.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -34,57 +34,44 @@ plugins/modules/uci.sh shebang
 plugins/modules/uci.sh validate-modules:invalid-extension
 plugins/modules/wrapper.sh shebang
 plugins/modules/wrapper.sh validate-modules:invalid-extension
-plugins/modules/apk.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/apk.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2016   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2059   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2091   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/group.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2016   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/nohup.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/ping.sh shellcheck:SC2319   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/service.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2012   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2155   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/slurp.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2005   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2162   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/tempfile.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC1087   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2012   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2119   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2120   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2155   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
+plugins/modules/apk.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/copy.sh shellcheck:SC2016   # Expressions don't expand in single quotes, use double quotes for that - https://www.shellcheck.net/wiki/SC2016
+plugins/modules/copy.sh shellcheck:SC2059   # Don't use variables in the `printf` format string. Use `printf "..%s.." "$foo"` - https://www.shellcheck.net/wiki/SC2059
+plugins/modules/copy.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/copy.sh shellcheck:SC2091   # Remove surrounding `$()` to avoid executing output (or use `eval` if intentional) - https://www.shellcheck.net/wiki/SC2091
+plugins/modules/copy.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/file.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/file.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/file.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/file.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/lineinfile.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/lineinfile.sh shellcheck:SC2016   # Expressions don't expand in single quotes, use double quotes for that - https://www.shellcheck.net/wiki/SC2016
+plugins/modules/lineinfile.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/opkg.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/opkg.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/ping.sh shellcheck:SC2319   # This `$?` refers to a condition, not a command. Assign to a variable to avoid it being overwritten - https://www.shellcheck.net/wiki/SC2319
+plugins/modules/setup.sh shellcheck:SC2012   # Use `find` instead of `ls` to better handle non-alphanumeric filenames - https://www.shellcheck.net/wiki/SC2012
+plugins/modules/setup.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/setup.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/setup.sh shellcheck:SC2155   # Declare and assign separately to avoid masking return values - https://www.shellcheck.net/wiki/SC2155
+plugins/modules/stat.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/stat.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/stat.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/sysctl.sh shellcheck:SC2005   # ShellCheck: SC2005 – - https://www.shellcheck.net/wiki/SC2005
+plugins/modules/sysctl.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/sysctl.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/sysctl.sh shellcheck:SC2162   # `read` without `-r` will mangle backslashes - https://www.shellcheck.net/wiki/SC2162
+plugins/modules/sysctl.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/uci.sh shellcheck:SC1087   # Use braces when expanding arrays, e.g. `${array[idx]}` (or `${var}[..` to quiet) - https://www.shellcheck.net/wiki/SC1087
+plugins/modules/uci.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/uci.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/uci.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/uci.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/wrapper.sh shellcheck:SC2012   # Use `find` instead of `ls` to better handle non-alphanumeric filenames - https://www.shellcheck.net/wiki/SC2012
+plugins/modules/wrapper.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/wrapper.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/wrapper.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/wrapper.sh shellcheck:SC2119   # Use `foo "$@"` if function's `$1` should mean script's `$1` - https://www.shellcheck.net/wiki/SC2119
+plugins/modules/wrapper.sh shellcheck:SC2120   # foo references arguments, but none are ever passed - https://www.shellcheck.net/wiki/SC2120
+plugins/modules/wrapper.sh shellcheck:SC2155   # Declare and assign separately to avoid masking return values - https://www.shellcheck.net/wiki/SC2155
+plugins/modules/wrapper.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -34,57 +34,44 @@ plugins/modules/uci.sh shebang
 plugins/modules/uci.sh validate-modules:invalid-extension
 plugins/modules/wrapper.sh shebang
 plugins/modules/wrapper.sh validate-modules:invalid-extension
-plugins/modules/apk.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/apk.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2016   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2059   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2091   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/copy.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/file.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/group.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2016   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/lineinfile.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/nohup.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/opkg.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/ping.sh shellcheck:SC2319   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/service.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2012   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/setup.sh shellcheck:SC2155   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/slurp.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/stat.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2005   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2162   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/sysctl.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/tempfile.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC1087   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2154   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/uci.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2012   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2015   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2046   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2086   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2119   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2120   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2155   # (failed to fetch: <urlopen error timed out>)
-plugins/modules/wrapper.sh shellcheck:SC2166   # (failed to fetch: <urlopen error timed out>)
+plugins/modules/apk.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/copy.sh shellcheck:SC2016   # Expressions don't expand in single quotes, use double quotes for that - https://www.shellcheck.net/wiki/SC2016
+plugins/modules/copy.sh shellcheck:SC2059   # Don't use variables in the `printf` format string. Use `printf "..%s.." "$foo"` - https://www.shellcheck.net/wiki/SC2059
+plugins/modules/copy.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/copy.sh shellcheck:SC2091   # Remove surrounding `$()` to avoid executing output (or use `eval` if intentional) - https://www.shellcheck.net/wiki/SC2091
+plugins/modules/copy.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/file.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/file.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/file.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/file.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/lineinfile.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/lineinfile.sh shellcheck:SC2016   # Expressions don't expand in single quotes, use double quotes for that - https://www.shellcheck.net/wiki/SC2016
+plugins/modules/lineinfile.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/opkg.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/opkg.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/ping.sh shellcheck:SC2319   # This `$?` refers to a condition, not a command. Assign to a variable to avoid it being overwritten - https://www.shellcheck.net/wiki/SC2319
+plugins/modules/setup.sh shellcheck:SC2012   # Use `find` instead of `ls` to better handle non-alphanumeric filenames - https://www.shellcheck.net/wiki/SC2012
+plugins/modules/setup.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/setup.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/setup.sh shellcheck:SC2155   # Declare and assign separately to avoid masking return values - https://www.shellcheck.net/wiki/SC2155
+plugins/modules/stat.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/stat.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/stat.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/sysctl.sh shellcheck:SC2005   # ShellCheck: SC2005 – - https://www.shellcheck.net/wiki/SC2005
+plugins/modules/sysctl.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/sysctl.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/sysctl.sh shellcheck:SC2162   # `read` without `-r` will mangle backslashes - https://www.shellcheck.net/wiki/SC2162
+plugins/modules/sysctl.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/uci.sh shellcheck:SC1087   # Use braces when expanding arrays, e.g. `${array[idx]}` (or `${var}[..` to quiet) - https://www.shellcheck.net/wiki/SC1087
+plugins/modules/uci.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/uci.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/uci.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/uci.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166
+plugins/modules/wrapper.sh shellcheck:SC2012   # Use `find` instead of `ls` to better handle non-alphanumeric filenames - https://www.shellcheck.net/wiki/SC2012
+plugins/modules/wrapper.sh shellcheck:SC2015   # Note that `A && B || C` is not if-then-else. C may run when A is true - https://www.shellcheck.net/wiki/SC2015
+plugins/modules/wrapper.sh shellcheck:SC2046   # Quote this to prevent word splitting - https://www.shellcheck.net/wiki/SC2046
+plugins/modules/wrapper.sh shellcheck:SC2086   # Double quote to prevent globbing and word splitting - https://www.shellcheck.net/wiki/SC2086
+plugins/modules/wrapper.sh shellcheck:SC2119   # Use `foo "$@"` if function's `$1` should mean script's `$1` - https://www.shellcheck.net/wiki/SC2119
+plugins/modules/wrapper.sh shellcheck:SC2120   # foo references arguments, but none are ever passed - https://www.shellcheck.net/wiki/SC2120
+plugins/modules/wrapper.sh shellcheck:SC2155   # Declare and assign separately to avoid masking return values - https://www.shellcheck.net/wiki/SC2155
+plugins/modules/wrapper.sh shellcheck:SC2166   # Prefer `[ p ] && [ q ]` as `[ p -a q ]` is not well-defined - https://www.shellcheck.net/wiki/SC2166


### PR DESCRIPTION
## SUMMARY
<!-- Describe the change below, including rationale and design decisions -->
For the time being, disabling SC2154 seems to be the most sensible option:

- all modules and wrapper.sh trigger it
- only new additions need to be monitored, that will require a bit more attention on the PRs, but there aren't many, and the module's code tend to be small rather than large.

<!-- If you are fixing an existing issue, uncomment the line below and adjust the number -->
Fixes #130 

<!-- See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->


<!-- Please do not forget to include a changelog fragment:
     https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
     No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
     Read about more details in CONTRIBUTING.md. -->

## ISSUE TYPE
<!-- Pick one or more below and delete the rest.
     'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

## COMPONENT NAME
<!-- This section will be filled automatically with the files changed in this PR.
     In case you want to do it, remove the start/end comments and
     write the SHORT NAME of the modules, plugins, tasks or features below. -->
<!-- component-name-start -->
<!-- component-name-end -->
