### PR TITLE
feat(action): add community.openwrt.wait_for_connection

### DIFF
--- a/plugins/action/wait_for_connection.py
+++ b/plugins/action/wait_for_connection.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2026 Alexei Znamensky
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from unittest import mock
+
+from ansible.plugins.action.wait_for_connection import ActionModule as WaitForConnectionActionModule
+
+from ansible_collections.community.openwrt.plugins.plugin_utils.openwrt_action import OpenwrtActionBase
+
+
+class ActionModule(OpenwrtActionBase, WaitForConnectionActionModule):
+    def run(self, tmp=None, task_vars=None):
+        _orig_execute_module = self._execute_module
+
+        def _execute_module(module_name=None, module_args=None, task_vars=None, **kwargs):
+            if module_name == "ansible.legacy.ping":
+                return self._run_shell_module("ping", {}, task_vars)
+            return _orig_execute_module(module_name=module_name, module_args=module_args, task_vars=task_vars, **kwargs)
+
+        with mock.patch.object(self, "_execute_module", _execute_module):
+            return WaitForConnectionActionModule.run(self, tmp, task_vars)

--- a/plugins/modules/wait_for_connection.py
+++ b/plugins/modules/wait_for_connection.py
@@ -1,0 +1,68 @@
+#!/usr/bin/python
+# Copyright (c) 2026 Alexei Znamensky
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+DOCUMENTATION = r"""
+module: wait_for_connection
+short_description: Waits until an OpenWrt device is reachable/usable
+description:
+  - Waits for a total of O(timeout) seconds.
+  - Retries the transport connection after a timeout of O(connect_timeout).
+  - Tests the transport connection every O(sleep) seconds.
+  - Uses M(community.openwrt.ping) to verify end-to-end connectivity without requiring Python on the target.
+author:
+  - Alexei Znamensky (@russoz)
+extends_documentation_fragment:
+  - community.openwrt.attributes
+attributes:
+  check_mode:
+    support: none
+  diff_mode:
+    support: none
+options:
+  connect_timeout:
+    description:
+      - Maximum number of seconds to wait for a connection to happen before closing and retrying.
+    type: int
+    default: 5
+  delay:
+    description:
+      - Number of seconds to wait before starting to poll.
+    type: int
+    default: 0
+  sleep:
+    description:
+      - Number of seconds to sleep between checks.
+    type: int
+    default: 1
+  timeout:
+    description:
+      - Maximum number of seconds to wait for.
+    type: int
+    default: 600
+seealso:
+  - module: ansible.builtin.wait_for_connection
+  - module: ansible.builtin.wait_for
+  - module: community.openwrt.ping
+"""
+
+EXAMPLES = r"""
+- name: Wait for OpenWrt device to become reachable
+  community.openwrt.wait_for_connection:
+
+- name: Wait up to 5 minutes, starting checks after 10 seconds
+  community.openwrt.wait_for_connection:
+    delay: 10
+    timeout: 300
+"""
+
+RETURN = r"""
+elapsed:
+  description: The number of seconds that elapsed waiting for the connection to appear.
+  returned: always
+  type: float
+  sample: 23.1
+"""

--- a/plugins/plugin_utils/openwrt_action.py
+++ b/plugins/plugin_utils/openwrt_action.py
@@ -41,24 +41,23 @@ class OpenwrtActionBase(ActionBase):
 
         module_name = self._task.action.split(".")[-1]
         try:
-            module_script_path = self._find_module_script(module_name)
-            remote_script = self._transfer_module_script(module_name, module_script_path)
+            result.update(self._run_shell_module(module_name, self._task.args.copy(), task_vars))
         except Exception as e:
             result["failed"] = True
             result["msg"] = str(e)
-            return result
-
-        module_args = self._task.args.copy()
-        module_args["_openwrt_script"] = remote_script
-        result.update(
-            self._execute_module(
-                module_name="community.openwrt.wrapper",
-                module_args=module_args,
-                task_vars=task_vars,
-            )
-        )
 
         return result
+
+    def _run_shell_module(self, module_name, module_args, task_vars):
+        """Find, transfer and execute a shell module via wrapper"""
+        module_script_path = self._find_module_script(module_name)
+        remote_script = self._transfer_module_script(module_name, module_script_path)
+        module_args["_openwrt_script"] = remote_script
+        return self._execute_module(
+            module_name="community.openwrt.wrapper",
+            module_args=module_args,
+            task_vars=task_vars,
+        )
 
     def _find_module_script(self, module_name):
         """Find the module's .sh file in the collection"""

--- a/tests/integration/targets/wait_for_connection/runme.sh
+++ b/tests/integration/targets/wait_for_connection/runme.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 Alexei Znamensky
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+export SCRIPT_DIR
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+exec "$OUTPUT_DIR/../../../utils/integration-common-runme.sh" "$(basename "$SCRIPT_DIR")" "$@"

--- a/tests/integration/targets/wait_for_connection/tasks/main.yml
+++ b/tests/integration/targets/wait_for_connection/tasks/main.yml
@@ -1,0 +1,14 @@
+# Copyright (c) 2026, Alexei Znamensky (@russoz)
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Wait for connection to OpenWrt device
+  community.openwrt.wait_for_connection:
+    timeout: 30
+  register: wfc_result
+
+- name: Assert wait_for_connection succeeded
+  ansible.builtin.assert:
+    that:
+      - wfc_result is succeeded
+      - wfc_result.elapsed is defined


### PR DESCRIPTION
## SUMMARY

Adds `community.openwrt.wait_for_connection`, which wraps the upstream `ansible.builtin.wait_for_connection` action plugin but redirects its internal `ansible.legacy.ping` call to `community.openwrt.ping` (shell-based). This avoids the `python3 not found` failure that occurs on OpenWrt devices, which have no Python installed.

The redirect is implemented using `mock.patch.object` on `_execute_module`, following the same pattern used by `community.openwrt.template`.

Also extracts a `_run_shell_module()` helper on `OpenwrtActionBase` to avoid duplication between action plugins.


## ISSUE TYPE

- New Module/Plugin Pull Request

## COMPONENT NAME

wait_for_connection

## ADDITIONAL INFORMATION

The handler in `roles/common/handlers/main.yml` still calls `ansible.builtin.wait_for_connection`. A follow-up PR will update it to use `community.openwrt.wait_for_connection`.