### PR TITLE
fix(roles/common): use community.openwrt.wait_for_connection in handler

### DIFF
--- a/changelogs/fragments/218-fix-wait-for-connection-handler.yml
+++ b/changelogs/fragments/218-fix-wait-for-connection-handler.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "roles/common - use ``community.openwrt.wait_for_connection`` in the ``Wait for connection`` handler to avoid the ``python3 not found`` failure
+    (https://github.com/ansible-collections/community.openwrt/issues/196, https://github.com/ansible-collections/community.openwrt/pull/218)."

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -22,7 +22,7 @@
     delay: 1
 
 - name: Wait for connection
-  ansible.builtin.wait_for_connection:
+  community.openwrt.wait_for_connection:
     timeout: "{{ openwrt_wait_for_connection_timeout | default(600) }}"
     delay: 5
   when: openwrt_wait_for_connection | default(true)


### PR DESCRIPTION
## SUMMARY

`ansible.builtin.wait_for_connection` internally calls `ansible.legacy.ping`, which requires Python on the target. OpenWrt has no Python, causing the "Wait for connection" handler to hang indefinitely after a network restart.

Switches the handler to `community.openwrt.wait_for_connection` (added in #216), which uses the shell-based `community.openwrt.ping` instead.

Fixes #196

## ISSUE TYPE

- Bugfix Pull Request

## COMPONENT NAME

roles/common