### PR TITLE
fix(copy): implement diff mode (#209)

### DIFF
--- a/changelogs/fragments/219-copy-diff.yml
+++ b/changelogs/fragments/219-copy-diff.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "copy - implement diff mode, which was declared as supported but never produced diff output (https://github.com/ansible-collections/community.openwrt/issues/209, https://github.com/ansible-collections/community.openwrt/pull/219)."

--- a/plugins/action/copy.py
+++ b/plugins/action/copy.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import os.path
 from tempfile import mkstemp
 
+from ansible import constants as C
 from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_bytes
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -85,6 +86,7 @@ class ActionModule(OpenwrtActionBase):
         self._task.args = self._task.args.copy()
         self._task.args["src"] = tmp_src
         self._task.args["_original_basename"] = os.path.basename(source)
+        self._task.args["_diff_max_bytes"] = C.MAX_FILE_SIZE_FOR_DIFF
         self._task.args.pop("content", None)
         return super().run(tmp, task_vars)
 

--- a/plugins/modules/copy.py
+++ b/plugins/modules/copy.py
@@ -87,6 +87,9 @@ options:
 notes:
   - This module does not support recursive directory copy. Only regular files can be copied.
   - Supports C(check_mode).
+  - Diff output is produced for text files only. Binary files are not detected and may render as corrupted
+    text diffs; avoid C(--diff) for binary transfers.
+  - Files larger than the controller's C(MAX_FILE_SIZE_FOR_DIFF) configuration are skipped in diff output.
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/copy.sh
+++ b/plugins/modules/copy.sh
@@ -12,6 +12,7 @@ PARAMS="
     original_basename=_original_basename/str
     src/str
     validate/str
+    _diff_max_bytes/int//104448
     $FILE_PARAMS
 "
 RESPONSE_VARS="src dest md5sum=md5sum_src checksum backup_file"
@@ -70,6 +71,21 @@ main() {
     [ -w "$tmp" ] || fail "Destination $tmp not writeable"
 
     [ "$md5sum_src" = "$md5sum_dest" -a ! -h "$dest" ] || {
+        [ -z "$_ansible_diff" ] || {
+            _diff_before=""
+            _diff_after=""
+            _src_size="$(wc -c < "$src" 2>/dev/null || echo 0)"
+            _dst_size=0
+            [ ! -e "$dest" ] || [ ! -r "$dest" ] || _dst_size="$(wc -c < "$dest" 2>/dev/null || echo 0)"
+            if [ "$_src_size" -gt "$_diff_max_bytes" ] || [ "$_dst_size" -gt "$_diff_max_bytes" ]; then
+                _diff_before="[diff skipped: file larger than $_diff_max_bytes bytes]"
+                _diff_after="$_diff_before"
+            else
+                [ "$_dst_size" = 0 ] || _diff_before="$(cat -- "$dest")"
+                _diff_after="$(cat -- "$src")"
+            fi
+            set_diff "$_diff_before" "$_diff_after" "$dest" "$dest"
+        }
         [ -n "$_ansible_check_mode" ] || {
             [ -z "$backup" ] || backup_file="$(backup_local "$dest")"
             [ ! -h "$dest" ] || { rm -f -- "$dest"; touch -- "$dest"; }

--- a/tests/integration/targets/copy/tasks/diff.yml
+++ b/tests/integration/targets/copy/tasks/diff.yml
@@ -1,0 +1,52 @@
+---
+# Copyright (c) 2026 Alexei Znamensky
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Diff on new file (dest does not exist)
+  community.openwrt.copy:
+    content: "line one\nline two\n"
+    dest: "{{ remote_tmp_dir }}/test_copy_diff_new.txt"
+  diff: true
+  check_mode: true
+  register: copy_diff_new
+
+- name: Assert diff was produced for new file
+  ansible.builtin.assert:
+    that:
+      - copy_diff_new is changed
+      - copy_diff_new.diff is defined
+      - copy_diff_new.diff.before == ""
+      - "'line one' in copy_diff_new.diff.after"
+
+- name: Seed an existing file for diff test
+  community.openwrt.copy:
+    content: "original\n"
+    dest: "{{ remote_tmp_dir }}/test_copy_diff_update.txt"
+
+- name: Diff on modified file
+  community.openwrt.copy:
+    content: "updated\n"
+    dest: "{{ remote_tmp_dir }}/test_copy_diff_update.txt"
+  diff: true
+  check_mode: true
+  register: copy_diff_update
+
+- name: Assert diff shows both before and after
+  ansible.builtin.assert:
+    that:
+      - copy_diff_update is changed
+      - "'original' in copy_diff_update.diff.before"
+      - "'updated' in copy_diff_update.diff.after"
+
+- name: No diff when content unchanged (idempotent)
+  community.openwrt.copy:
+    content: "original\n"
+    dest: "{{ remote_tmp_dir }}/test_copy_diff_update.txt"
+  diff: true
+  register: copy_diff_noop
+
+- name: Assert no change on idempotent run
+  ansible.builtin.assert:
+    that:
+      - copy_diff_noop is not changed

--- a/tests/integration/targets/copy/tasks/main.yml
+++ b/tests/integration/targets/copy/tasks/main.yml
@@ -177,3 +177,6 @@
       - >-
         "vault" in (copy_vault_decrypt_fail.msg | lower)
         or "vault" in (copy_vault_decrypt_fail.exception | default("") | lower)
+
+- name: Diff mode tests
+  ansible.builtin.include_tasks: diff.yml


### PR DESCRIPTION
## Summary
- Implements diff mode for [community.openwrt.copy](plugins/modules/copy.sh), which previously declared `diff_mode: full` but never emitted diff output (see #209).
- Action plugin passes `C.MAX_FILE_SIZE_FOR_DIFF` to the module as `_diff_max_bytes`; shell module skips content capture when either side exceeds the cap.
- Binary files remain unsupported (documented in module notes).

## Test plan
- [x] `andebox test integration -- -v copy` passes on openwrt 23.05, 24.10, 25.12
- [x] New diff cases cover: new file, modified file, idempotent no-op

Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)