### PR TITLE
feature(apk): Add option allow_untrusted to be able to install local packages (#195)

### DIFF
--- a/changelogs/fragments/220-apk-allow-untrusted.yml
+++ b/changelogs/fragments/220-apk-allow-untrusted.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "apk - add option ``allow_untrusted`` to be able to install local packages (https://github.com/ansible-collections/community.openwrt/issues/195, https://github.com/ansible-collections/community.openwrt/pull/224)"

--- a/plugins/modules/apk.py
+++ b/plugins/modules/apk.py
@@ -55,6 +55,11 @@ options:
       - Continue even if package dependencies are broken.
     type: bool
     default: false
+  allow_untrusted:
+    description:
+      - To install a locally available apk package, for example if this device has no internet access but you can upload apk packages directly to it.
+    type: bool
+    default: false
 """
 
 EXAMPLES = r"""
@@ -79,6 +84,12 @@ EXAMPLES = r"""
     name: tcpdump
     state: present
     no_cache: true
+
+- name: Install local package
+  community.openwrt.apk:
+    name: /path/to/file.apk
+    state: present
+    allow_untrusted: true
 """
 
 RETURN = r""""""

--- a/plugins/modules/apk.py
+++ b/plugins/modules/apk.py
@@ -55,6 +55,12 @@ options:
       - Continue even if package dependencies are broken.
     type: bool
     default: false
+  allow_untrusted:
+    description:
+      - To install a locally available apk package, for example if this device has no internet access but you can upload apk packages directly to it.
+    type: bool
+    default: false
+    version_added: 1.5.0
 """
 
 EXAMPLES = r"""
@@ -79,6 +85,12 @@ EXAMPLES = r"""
     name: tcpdump
     state: present
     no_cache: true
+
+- name: Install local package
+  community.openwrt.apk:
+    name: /path/to/file.apk
+    state: present
+    allow_untrusted: true
 """
 
 RETURN = r""""""

--- a/plugins/modules/apk.sh
+++ b/plugins/modules/apk.sh
@@ -20,7 +20,7 @@ install_packages() {
     [ -n "$pkgs_to_install" ] || return 0
 
     [ -n "$_ansible_check_mode" ] || {
-        apk $update_cache $no_cache $force_broken_world add $pkgs_to_install >"$out" 2>"$err"
+        apk $update_cache $no_cache $force_broken_world $allow_untrusted add $pkgs_to_install >"$out" 2>"$err"
         rc=$?
         stdout="$(cat "$out")"
         stderr="$(cat "$err")"
@@ -62,6 +62,7 @@ init() {
         update_cache/bool
         no_cache/bool
         force_broken_world/bool
+        allow_untrusted/bool
     "
     RESPONSE_VARS="
         stdout/str/a
@@ -91,6 +92,7 @@ main() {
     [ -z "$update_cache" ] || update_cache="--update-cache"
     [ -z "$no_cache" ] || no_cache="--no-cache"
     [ -z "$force_broken_world" ] || force_broken_world="--force-broken-world"
+    [ -z "$allow_untrusted" ] || allow_untrusted="--allow-untrusted"
 
     case "$state" in
         present|installed) install_packages;;

--- a/plugins/modules/apk.sh
+++ b/plugins/modules/apk.sh
@@ -20,12 +20,18 @@ install_packages() {
     [ -n "$pkgs_to_install" ] || return 0
 
     [ -n "$_ansible_check_mode" ] || {
-        apk $update_cache $no_cache $force_broken_world add $pkgs_to_install >"$out" 2>"$err"
+        apk $update_cache $no_cache $force_broken_world $allow_untrusted add $pkgs_to_install >"$out" 2>"$err"
         rc=$?
         stdout="$(cat "$out")"
         stderr="$(cat "$err")"
         # Verify installation
         for pkg in $pkgs_to_install; do
+            if [ -f "$pkg" ]; then
+                # we installed a file and have to query the file for the package name to verify its installation
+                json_load "$(apk adbdump --format json "$pkg")" || fail "could not parse output of apk adbdump"
+                json_select "info"
+                json_get_var pkg "name"
+            fi
             query_package "$pkg" || fail "failed to install $pkg: $stdout $stderr"
         done
     }
@@ -62,6 +68,7 @@ init() {
         update_cache/bool
         no_cache/bool
         force_broken_world/bool
+        allow_untrusted/bool
     "
     RESPONSE_VARS="
         stdout/str/a
@@ -91,6 +98,7 @@ main() {
     [ -z "$update_cache" ] || update_cache="--update-cache"
     [ -z "$no_cache" ] || no_cache="--no-cache"
     [ -z "$force_broken_world" ] || force_broken_world="--force-broken-world"
+    [ -z "$allow_untrusted" ] || allow_untrusted="--allow-untrusted"
 
     case "$state" in
         present|installed) install_packages;;

--- a/tests/integration/targets/apk/meta/main.yml
+++ b/tests/integration/targets/apk/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/apk/tasks/main.yml
+++ b/tests/integration/targets/apk/tasks/main.yml
@@ -37,3 +37,27 @@
       ansible.builtin.assert:
         that:
           - apk_remove is succeeded
+
+    - name: Test --allow-untrusted
+      block:
+        - name: Download a test package
+          ansible.builtin.command:
+            cmd: 'apk fetch htop -s > /tmp/htop.apk'
+
+        - name: Install untrusted package
+          community.openwrt.apk:
+            name: /tmp/htop.apk
+            state: present
+            allow_untrusted: true
+
+        - name: "Verify package is installed"
+          community.openwrt.command:
+            cmd: apk info -e htop
+          register: apk_verify_untrusted
+          failed_when: apk_verify_untrusted.rc != 0
+
+      finally:
+        - name: Remove downloaded package
+          ansible.builtin.file:
+            path: /tmp/htop.apk
+            state: absent

--- a/tests/integration/targets/apk/tasks/main.yml
+++ b/tests/integration/targets/apk/tasks/main.yml
@@ -37,3 +37,30 @@
       ansible.builtin.assert:
         that:
           - apk_remove is succeeded
+
+    - name: Test --allow-untrusted
+      block:
+        - name: Download a test package
+          community.openwrt.command:
+            cmd: 'apk fetch terminfo -o {{ remote_tmp_dir }}'
+          register: apk_fetch_result
+
+        - name: Set apk filename
+          ansible.builtin.set_fact:
+            apk_terminfo_filename: "{{ remote_tmp_dir }}/{{ apk_fetch_result.stdout_lines[0].split(' ')[1] }}.apk"
+
+        - name: Output apk filename
+          ansible.builtin.debug:
+            var: apk_terminfo_filename
+
+        - name: Install untrusted package
+          community.openwrt.apk:
+            name: "{{ apk_terminfo_filename }}"
+            state: present
+            allow_untrusted: true
+
+        - name: "Verify package is installed"
+          community.openwrt.command:
+            cmd: apk info -e terminfo
+          register: apk_verify_untrusted
+          failed_when: apk_verify_untrusted.rc != 0


### PR DESCRIPTION
## SUMMARY
Add feature to `apk` to install local packages by adding the `--allow-untrusted` option

Fixes #195

## ISSUE TYPE
- Feature Pull Request

## COMPONENT NAME
<!-- component-name-start -->
plugins/modules/apk.py
plugins/modules/apk.sh
<!-- component-name-end -->

## ADDITIONAL INFORMATION
We certainly should add tests for it as well. Almighty AI says building APKs is quite easy:
- `install alpine-sdk`
- `mkdir -p /tmp/packages/testpkg`
- with workdir `/tmp/packages/testpkg`: `abuild init`
- write to `/tmp/packages/testpkg/APKBUILD`:
```
# Maintainer: Test <test@example.com>
pkgname=testpkg
pkgver=1.0
pkgrel=0
pkgdesc="Minimal test package"
url="https://example.com"
arch="all"
license="MIT"
options="!check"

package() {
    install -Dm644 /dev/null "$pkgdir"/usr/share/testpkg/placeholder
}
```
- with workdir `/tmp/packages/testpkg`: `abuild -r` -> creates `/tmp/packages/testpkg/pkg/testpkg-1.0-r0.apk`

Alternatively we could do it by hand:
- Write to `/tmp/testpkg/.PKGINFO`:
```
pkgname = testpkg
pkgver = 1.0-r0
arch = x86_64
license = MIT
```
- `tar -cvzf testpkg-1.0-r0.apk -C /tmp/testpkg /tmp/`

I'd go with the 2nd option? wdyt?

I haven't set up a local test environment, yet :)