### PR TITLE
Add uci find_all command support

### DIFF
--- a/changelogs/fragments/uci-find-all-command.yml
+++ b/changelogs/fragments/uci-find-all-command.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - uci - add ``find_all`` to the Python module metadata command choices and return its matches in ``result_list`` (https://github.com/ansible-collections/community.openwrt/pull/242).

--- a/plugins/modules/uci.py
+++ b/plugins/modules/uci.py
@@ -40,6 +40,7 @@ options:
       - del_list
       - export
       - find
+      - find_all
       - get
       - import
       - rename
@@ -166,8 +167,11 @@ result:
   type: str
   sample: cfg12523
 result_list:
-  description: The list form of result.
-  returned: when O(command=get)
+  description:
+    - The list form of C(result).
+    - For O(command=find_all), this is the list of matching positional section IDs, for example V(@wifi-iface[0]).
+      Named sections are returned as positional IDs.
+  returned: when O(command=get) or O(command=find_all)
   type: list
   sample: ["0.pool.ntp.org", "1.pool.ntp.org"]
 config:

--- a/plugins/modules/uci.sh
+++ b/plugins/modules/uci.sh
@@ -163,7 +163,7 @@ uci_find() {
                 [ -n "$option" -o "$command" = find_all ] ||
                 fail "config, type and option required for $command";;
     esac
-    [ "$command" != "find_all" ] || uci_result_do json_add_array result
+    [ "$command" != "find_all" ] || uci_result_do json_add_array result_list
     type="${type:-$section}"
     section=""; i=0
     while [ -n "$(uci -q get "$config.@$type[$i]")" ]; do

--- a/tests/integration/targets/uci/tasks/main.yml
+++ b/tests/integration/targets/uci/tasks/main.yml
@@ -59,6 +59,21 @@
     option: testopt
     value: testval
 
+- name: "find_all - setup: add another matching test section"
+  community.openwrt.uci:
+    command: add
+    config: uhttpd
+    type: testtype
+  register: uci_add_second_section
+
+- name: "find_all - setup: set option on second test section"
+  community.openwrt.uci:
+    command: set
+    config: uhttpd
+    section: "{{ uci_add_second_section.result }}"
+    option: testopt
+    value: testval
+
 - name: "find - match found: find the test section by option value"
   community.openwrt.uci:
     command: find
@@ -75,6 +90,75 @@
       - uci_find_match.result is defined
       - uci_find_match.section is defined
       - uci_find_match.result == uci_find_match.section
+
+- name: "find_all - matches found: find all matching test sections by option value"
+  community.openwrt.uci:
+    command: find_all
+    config: uhttpd
+    type: testtype
+    option: testopt
+    find: testval
+  register: uci_find_all_match
+
+- name: "find_all - matches found: assert result contains all matching sections"
+  ansible.builtin.assert:
+    that:
+      - uci_find_all_match is succeeded
+      - uci_find_all_match.result_list is defined
+      - uci_find_all_match.result_list is not string
+      - uci_find_all_match.result_list is sequence
+      - uci_find_all_match.result_list == ["@testtype[0]", "@testtype[1]"]
+
+- name: "find_all - type only: find all matching test sections by type"
+  community.openwrt.uci:
+    command: find_all
+    config: uhttpd
+    type: testtype
+  register: uci_find_all_type
+
+- name: "find_all - type only: assert result contains matching sections"
+  ansible.builtin.assert:
+    that:
+      - uci_find_all_type is succeeded
+      - uci_find_all_type.result_list is defined
+      - uci_find_all_type.result_list is not string
+      - uci_find_all_type.result_list is sequence
+      - uci_find_all_type.result_list == ["@testtype[0]", "@testtype[1]"]
+
+- name: "find_all - option exists: find all matching test sections with option"
+  community.openwrt.uci:
+    command: find_all
+    config: uhttpd
+    type: testtype
+    option: testopt
+  register: uci_find_all_option
+
+- name: "find_all - option exists: assert result contains matching sections"
+  ansible.builtin.assert:
+    that:
+      - uci_find_all_option is succeeded
+      - uci_find_all_option.result_list is defined
+      - uci_find_all_option.result_list is not string
+      - uci_find_all_option.result_list is sequence
+      - uci_find_all_option.result_list == ["@testtype[0]", "@testtype[1]"]
+
+- name: "find_all - no match: search for a non-existent option value"
+  community.openwrt.uci:
+    command: find_all
+    config: uhttpd
+    type: testtype
+    option: testopt
+    find: nonexistent
+  register: uci_find_all_no_match
+
+- name: "find_all - no match: assert result is an empty list"
+  ansible.builtin.assert:
+    that:
+      - uci_find_all_no_match is succeeded
+      - uci_find_all_no_match.result_list is defined
+      - uci_find_all_no_match.result_list is not string
+      - uci_find_all_no_match.result_list is sequence
+      - uci_find_all_no_match.result_list | length == 0
 
 - name: "find - no match: search for a non-existent option value"
   community.openwrt.uci:
@@ -100,4 +184,11 @@
     command: delete
     config: uhttpd
     section: "{{ uci_add_section.result }}"
+  ignore_errors: true
+
+- name: "find - teardown: delete the second test section"
+  community.openwrt.uci:
+    command: delete
+    config: uhttpd
+    section: "{{ uci_add_second_section.result }}"
   ignore_errors: true


### PR DESCRIPTION
## SUMMARY
<!-- Describe the change below, including rationale and design decisions -->
Add support for the internal `find_all` command to `community.openwrt.uci`.

The command is already implemented by the shell backend. This change exposes it in the module metadata and returns all matching section references through `result_list`.

<!-- If you are fixing an existing issue, uncomment the line below and adjust the number -->
<!-- Fixes #nnnn -->

<!-- See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->


<!-- Please do not forget to include a changelog fragment:
     https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
     No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
     Read about more details in CONTRIBUTING.md. -->

## ISSUE TYPE
<!-- Pick one or more below and delete the rest.
     'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Feature Pull Request

## COMPONENT NAME
<!-- This section will be filled automatically with the files changed in this PR.
     In case you want to do it, remove the start/end comments and
     write the SHORT NAME of the modules, plugins, tasks or features below. -->
<!-- component-name-start -->
plugins/modules/uci.py
<!-- component-name-end -->

## ADDITIONAL INFORMATION
<!-- Include additional information to help people understand the change here -->
<!-- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
