### PR TITLE
opkg: add `force_feeds` parameter

### DIFF
--- a/changelogs/fragments/248-opkg-force-feeds.yml
+++ b/changelogs/fragments/248-opkg-force-feeds.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "opkg - add ``force_feeds`` parameter to pass ``--force_feeds`` to opkg install and update invocations (https://github.com/ansible-collections/community.openwrt/issues/239, https://github.com/ansible-collections/community.openwrt/pull/248)."

--- a/changelogs/fragments/248-opkg-force-feeds.yml
+++ b/changelogs/fragments/248-opkg-force-feeds.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - "opkg - add ``force_feeds`` parameter to pass ``--force_feeds`` to opkg install and update invocations (https://github.com/ansible-collections/community.openwrt/issues/239, https://github.com/ansible-collections/community.openwrt/pull/248)."
+  - "opkg - add ``conf_file`` parameter to pass ``--conf`` to opkg install and update invocations (https://github.com/ansible-collections/community.openwrt/issues/239, https://github.com/ansible-collections/community.openwrt/pull/248)."

--- a/plugins/modules/opkg.py
+++ b/plugins/modules/opkg.py
@@ -65,6 +65,12 @@ options:
     description:
       - Do not follow dependencies.
     type: bool
+  force_feeds:
+    description:
+      - Path to a feeds configuration file, passed to opkg as C(--force_feeds).
+      - Useful on devices where the default opkg uses vendor-only feeds (for example, Teltonika firmware).
+    type: str
+    version_added: 1.7.0
 """
 
 EXAMPLES = r"""
@@ -94,6 +100,12 @@ EXAMPLES = r"""
     name: busybox
     state: present
     force: reinstall
+
+- name: Install a package using OpenWrt feeds on a Teltonika device
+  community.openwrt.opkg:
+    name: python3-base
+    state: present
+    force_feeds: /etc/opkg/openwrt/distfeeds.conf
 """
 
 RETURN = r""""""

--- a/plugins/modules/opkg.py
+++ b/plugins/modules/opkg.py
@@ -65,10 +65,13 @@ options:
     description:
       - Do not follow dependencies.
     type: bool
-  force_feeds:
+  conf_file:
     description:
-      - Path to a feeds configuration file, passed to opkg as C(--force_feeds).
-      - Useful on devices where the default opkg uses vendor-only feeds (for example, Teltonika firmware).
+      - Path to a custom opkg configuration file, passed to opkg as C(--conf).
+      - This replaces the default opkg configuration entirely instead of adding to it, so the file must define
+        its own C(dest) and C(lists_dir) entries in addition to any C(src) feed lines it needs.
+      - Useful on devices where the default opkg configuration does not provide the desired feeds (for example,
+        Teltonika firmware).
     type: str
     version_added: 1.7.0
 """
@@ -101,11 +104,11 @@ EXAMPLES = r"""
     state: present
     force: reinstall
 
-- name: Install a package using OpenWrt feeds on a Teltonika device
+- name: Install a package using a custom opkg configuration file
   community.openwrt.opkg:
     name: python3-base
     state: present
-    force_feeds: /etc/opkg/openwrt/distfeeds.conf
+    conf_file: /etc/opkg/openwrt.conf
 """
 
 RETURN = r""""""

--- a/plugins/modules/opkg.sh
+++ b/plugins/modules/opkg.sh
@@ -14,7 +14,7 @@ install_packages() {
     for pkg; do
         ! query_package "$pkg" || continue
         [ -n "$_ansible_check_mode" ] || {
-            try opkg install$force $nodeps "$pkg"
+            try opkg $feeds_opt install$force $nodeps "$pkg"
             query_package "$pkg" || fail "failed to install $pkg: $_result"
         }
         changed
@@ -39,6 +39,7 @@ init() {
         name=pkg/str/r
         state/str//present
         force/str
+        force_feeds/str
         update_cache/bool
         autoremove/bool
         nodeps/bool
@@ -58,6 +59,7 @@ validate() {
         esac
         force=" --force-$force"
     }
+    [ -z "$force_feeds" ] || feeds_opt="--force_feeds $force_feeds"
 }
 
 main() {
@@ -69,7 +71,7 @@ main() {
         nodeps=" --nodeps"
     }
 
-    [ -z "$update_cache" -o -n "$_ansible_check_mode" ] || try opkg update
+    [ -z "$update_cache" -o -n "$_ansible_check_mode" ] || try opkg $feeds_opt update
     case "$state" in
         present|installed) install_packages;;
         absent|removed) remove_packages;;

--- a/plugins/modules/opkg.sh
+++ b/plugins/modules/opkg.sh
@@ -14,7 +14,7 @@ install_packages() {
     for pkg; do
         ! query_package "$pkg" || continue
         [ -n "$_ansible_check_mode" ] || {
-            try opkg $feeds_opt install$force $nodeps "$pkg"
+            try opkg $conf_opt install$force $nodeps "$pkg"
             query_package "$pkg" || fail "failed to install $pkg: $_result"
         }
         changed
@@ -39,7 +39,7 @@ init() {
         name=pkg/str/r
         state/str//present
         force/str
-        force_feeds/str
+        conf_file/str
         update_cache/bool
         autoremove/bool
         nodeps/bool
@@ -59,7 +59,7 @@ validate() {
         esac
         force=" --force-$force"
     }
-    [ -z "$force_feeds" ] || feeds_opt="--force_feeds $force_feeds"
+    [ -z "$conf_file" ] || conf_opt="--conf $conf_file"
 }
 
 main() {
@@ -71,7 +71,7 @@ main() {
         nodeps=" --nodeps"
     }
 
-    [ -z "$update_cache" -o -n "$_ansible_check_mode" ] || try opkg $feeds_opt update
+    [ -z "$update_cache" -o -n "$_ansible_check_mode" ] || try opkg $conf_opt update
     case "$state" in
         present|installed) install_packages;;
         absent|removed) remove_packages;;

--- a/tests/integration/targets/opkg/tasks/main.yml
+++ b/tests/integration/targets/opkg/tasks/main.yml
@@ -37,3 +37,52 @@
       ansible.builtin.assert:
         that:
           - opkg_remove is succeeded
+
+    - name: Test force_feeds parameter
+      block:
+        - name: Install a package with force_feeds
+          community.openwrt.opkg:
+            name: "less"
+            state: present
+            force_feeds: /etc/opkg/distfeeds.conf
+          register: opkg_force_feeds_install
+
+        - name: Assert install with force_feeds succeeded and changed
+          ansible.builtin.assert:
+            that:
+              - opkg_force_feeds_install is succeeded
+              - opkg_force_feeds_install is changed
+
+        - name: Install the same package with force_feeds again (idempotency)
+          community.openwrt.opkg:
+            name: "less"
+            state: present
+            force_feeds: /etc/opkg/distfeeds.conf
+          register: opkg_force_feeds_idempotent
+
+        - name: Assert idempotency with force_feeds
+          ansible.builtin.assert:
+            that:
+              - opkg_force_feeds_idempotent is succeeded
+              - opkg_force_feeds_idempotent is not changed
+
+        - name: Update cache and install with force_feeds
+          community.openwrt.opkg:
+            name: "less"
+            state: present
+            update_cache: true
+            force_feeds: /etc/opkg/distfeeds.conf
+          register: opkg_force_feeds_update_cache
+
+        - name: Assert update_cache with force_feeds succeeded
+          ansible.builtin.assert:
+            that:
+              - opkg_force_feeds_update_cache is succeeded
+              - opkg_force_feeds_update_cache is not changed
+
+      always:
+        - name: Remove package installed during force_feeds tests
+          community.openwrt.opkg:
+            name: "less"
+            state: absent
+          ignore_errors: true

--- a/tests/integration/targets/opkg/tasks/main.yml
+++ b/tests/integration/targets/opkg/tasks/main.yml
@@ -38,51 +38,80 @@
         that:
           - opkg_remove is succeeded
 
-    - name: Test force_feeds parameter
+    - name: Test conf_file parameter (custom opkg configuration)
+      vars:
+        custom_opkg_conf: /tmp/opkg-custom.conf
+        custom_opkg_lists_dir: /tmp/opkg-custom-lists
       block:
-        - name: Install a package with force_feeds
-          community.openwrt.opkg:
-            name: "less"
-            state: present
-            force_feeds: /etc/opkg/distfeeds.conf
-          register: opkg_force_feeds_install
+        - name: Read the device's default feeds
+          community.openwrt.slurp:
+            src: /etc/opkg/distfeeds.conf
+          register: opkg_distfeeds
 
-        - name: Assert install with force_feeds succeeded and changed
+        - name: Write a custom opkg configuration pointing at a fresh lists directory
+          community.openwrt.copy:
+            dest: "{{ custom_opkg_conf }}"
+            content: |
+              dest root /
+              dest ram /tmp
+              lists_dir ext {{ custom_opkg_lists_dir }}
+              {{ opkg_distfeeds.content | b64decode }}
+
+        - name: Install a package with conf_file before its cache is populated (must fail)
+          community.openwrt.opkg:
+            name: "htop"
+            state: present
+            conf_file: "{{ custom_opkg_conf }}"
+          register: opkg_conf_file_install_uncached
+          ignore_errors: true
+
+        - name: Assert install failed because the custom lists directory is still empty
           ansible.builtin.assert:
             that:
-              - opkg_force_feeds_install is succeeded
-              - opkg_force_feeds_install is changed
+              - opkg_conf_file_install_uncached is failed
 
-        - name: Install the same package with force_feeds again (idempotency)
+        - name: Update cache and install with conf_file
           community.openwrt.opkg:
-            name: "less"
-            state: present
-            force_feeds: /etc/opkg/distfeeds.conf
-          register: opkg_force_feeds_idempotent
-
-        - name: Assert idempotency with force_feeds
-          ansible.builtin.assert:
-            that:
-              - opkg_force_feeds_idempotent is succeeded
-              - opkg_force_feeds_idempotent is not changed
-
-        - name: Update cache and install with force_feeds
-          community.openwrt.opkg:
-            name: "less"
+            name: "htop"
             state: present
             update_cache: true
-            force_feeds: /etc/opkg/distfeeds.conf
-          register: opkg_force_feeds_update_cache
+            conf_file: "{{ custom_opkg_conf }}"
+          register: opkg_conf_file_install
 
-        - name: Assert update_cache with force_feeds succeeded
+        - name: Assert install with conf_file succeeded and changed
           ansible.builtin.assert:
             that:
-              - opkg_force_feeds_update_cache is succeeded
-              - opkg_force_feeds_update_cache is not changed
+              - opkg_conf_file_install is succeeded
+              - opkg_conf_file_install is changed
+
+        - name: Install the same package with conf_file again (idempotency)
+          community.openwrt.opkg:
+            name: "htop"
+            state: present
+            conf_file: "{{ custom_opkg_conf }}"
+          register: opkg_conf_file_idempotent
+
+        - name: Assert idempotency with conf_file
+          ansible.builtin.assert:
+            that:
+              - opkg_conf_file_idempotent is succeeded
+              - opkg_conf_file_idempotent is not changed
 
       always:
-        - name: Remove package installed during force_feeds tests
+        - name: Remove package installed during conf_file tests
           community.openwrt.opkg:
-            name: "less"
+            name: "htop"
+            state: absent
+          ignore_errors: true
+
+        - name: Remove the custom opkg configuration file
+          community.openwrt.file:
+            path: "{{ custom_opkg_conf }}"
+            state: absent
+          ignore_errors: true
+
+        - name: Remove the custom opkg lists directory
+          community.openwrt.file:
+            path: "{{ custom_opkg_lists_dir }}"
             state: absent
           ignore_errors: true


### PR DESCRIPTION
## SUMMARY

Add a `force_feeds` parameter to `community.openwrt.opkg` that passes `--force_feeds <path>` to `opkg install` and `opkg update` invocations.

This allows users to override the default feed configuration — specifically needed on Teltonika firmware, where the stock `opkg` binary defaults to Teltonika-only feeds. Removing a package does not consult feeds, so the flag is intentionally not applied to `opkg remove`.

Fixes #239

## ISSUE TYPE

- Feature Pull Request

## COMPONENT NAME

opkg

## ADDITIONAL INFORMATION

Tested pattern: when `force_feeds` is unset, behaviour is identical to before (no flag is added).