### PR TITLE
init role: fix hard `failed_when: false` obfuscating real failures

### DIFF
--- a/changelogs/fragments/253-init-role-failed-when.yml
+++ b/changelogs/fragments/253-init-role-failed-when.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - init role - do not suppress real module failures when checking for opkg/apk availability (https://github.com/ansible-collections/community.openwrt/issues/250, https://github.com/ansible-collections/community.openwrt/pull/253).

--- a/roles/init/molecule/no_pkg_manager/converge.yml
+++ b/roles/init/molecule/no_pkg_manager/converge.yml
@@ -15,12 +15,12 @@
             ansible_host: 192.168.255.255
             openwrt_install_recommended_packages: false
       rescue:
-        - name: Assert role fails
+        - name: Assert role fails with the real connection error
           ansible.builtin.assert:
             that:
               - ansible_failed_result is failed
               - >-
-                'Could not find package manager:' in ansible_failed_result.msg
+                'Could not find package manager:' not in ansible_failed_result.msg
 
     - name: Remove package managers
       community.openwrt.command:

--- a/roles/init/tasks/main.yml
+++ b/roles/init/tasks/main.yml
@@ -22,7 +22,9 @@
   register: _opkg_available
   check_mode: false
   changed_when: false
-  failed_when: false
+  failed_when: >-
+    _opkg_available.rc is not defined or
+    (_opkg_available.rc != 0 and _opkg_available.stderr != "")
 
 - name: Check for apk availability
   community.openwrt.command:
@@ -30,7 +32,9 @@
   register: _apk_available
   check_mode: false
   changed_when: false
-  failed_when: false
+  failed_when: >-
+    _apk_available.rc is not defined or
+    (_apk_available.rc != 0 and _apk_available.stderr != "")
 
 - name: Assert package manager is found
   ansible.builtin.assert:


### PR DESCRIPTION
## SUMMARY
The `opkg`/`apk` availability checks in the `init` role used a blanket `failed_when: false`, meant to tolerate `which` reporting the package manager as not found. That same override also swallowed genuine module-execution failures unrelated to "not found" (e.g. a full disk causing the module script transfer to fail), so the role reported only a misleading "neither apk nor opkg is available" assertion failure instead of the real cause.

`failed_when` now only tolerates the expected case (non-zero `rc` with empty `stderr`); any other failure (undefined `rc` from a transfer/exec error, or non-zero `rc` with actual `stderr` output) now fails the task with its real message.

The existing `no_pkg_manager` molecule scenario had a test block that (unintentionally) relied on the old obfuscating behavior, expecting the generic "Could not find package manager" message even when the underlying cause was a temp-directory/exec failure. Updated that assertion to confirm the real error now surfaces.

Fixes #250

## ISSUE TYPE
- Bugfix Pull Request

## COMPONENT NAME
roles/init/tasks/main.yml

## ADDITIONAL INFORMATION
All `init` role molecule scenarios (`no_pkg_manager`, `install_recommended_true`, `install_recommended_false`) pass, and sanity is clean on the changed files.