### PR TITLE
template: restore `failed_when` support for missing `src`

### DIFF
--- a/changelogs/fragments/254-template-action-error-handling.yml
+++ b/changelogs/fragments/254-template-action-error-handling.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "template action plugin - work around an ansible-core change that made this action ignore ``failed_when`` (https://github.com/ansible-collections/community.openwrt/issues/252, https://github.com/ansible-collections/community.openwrt/pull/254)."

--- a/plugins/action/template.py
+++ b/plugins/action/template.py
@@ -40,6 +40,9 @@ class ActionModule(TemplateActionModule):
             with mock.patch.object(action_loader, "get", _get_action):
                 return super().run(tmp, task_vars)
         except AnsibleAction as e:
-            return e.result
+            result = dict(e.result)
+            result["_debug_exc_type"] = type(e).__name__
+            result["_debug_exc_str"] = to_native(e)
+            return result
         except Exception as e:
-            return {"failed": True, "msg": to_native(e)}
+            return {"failed": True, "msg": to_native(e), "_debug_exc_type": type(e).__name__}

--- a/plugins/action/template.py
+++ b/plugins/action/template.py
@@ -40,9 +40,11 @@ class ActionModule(TemplateActionModule):
             with mock.patch.object(action_loader, "get", _get_action):
                 return super().run(tmp, task_vars)
         except AnsibleAction as e:
+            # e.result should already carry "msg", but on some platforms it comes back
+            # without one; fall back to the exception's own message so callers always
+            # get an explanation.
             result = dict(e.result)
-            result["_debug_exc_type"] = type(e).__name__
-            result["_debug_exc_str"] = to_native(e)
+            result.setdefault("msg", to_native(e))
             return result
         except Exception as e:
-            return {"failed": True, "msg": to_native(e), "_debug_exc_type": type(e).__name__}
+            return {"failed": True, "msg": to_native(e)}

--- a/plugins/action/template.py
+++ b/plugins/action/template.py
@@ -1,9 +1,12 @@
+# Copyright (c) 2026 Alexei Znamensky (@russoz)
 # Copyright (c) 2026 Ilya Bogdanov (@zeerayne)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import mock
 
+from ansible.errors import AnsibleAction
+from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.action.template import ActionModule as TemplateActionModule
 from ansible.plugins.loader import action_loader
 
@@ -28,5 +31,15 @@ class ActionModule(TemplateActionModule):
                 shared_loader_obj=shared_loader_obj,
             )
 
-        with mock.patch.object(action_loader, "get", _get_action):
-            return super().run(tmp, task_vars)
+        # ansible-core >= 2.19 (https://github.com/ansible/ansible/pull/84621) dropped the
+        # try/except that used to keep this action from ever raising, so errors such as a
+        # missing "src" file now escape uncaught and bypass failed_when/changed_when
+        # evaluation entirely (https://github.com/ansible/ansible/issues/87491). Restore the
+        # pre-2.19 contract of always returning a result dict instead of raising.
+        try:
+            with mock.patch.object(action_loader, "get", _get_action):
+                return super().run(tmp, task_vars)
+        except AnsibleAction as e:
+            return e.result
+        except Exception as e:
+            return {"failed": True, "msg": to_native(e)}

--- a/tests/integration/targets/template/tasks/main.yml
+++ b/tests/integration/targets/template/tasks/main.yml
@@ -72,6 +72,11 @@
   register: template_missing
   failed_when: false
 
+- name: DEBUG dump full template_missing result
+  ansible.builtin.debug:
+    msg: "{{ template_missing }}"
+    verbosity: 0
+
 - name: Assert a missing src is reported as a normal result honoring failed_when
   ansible.builtin.assert:
     that:

--- a/tests/integration/targets/template/tasks/main.yml
+++ b/tests/integration/targets/template/tasks/main.yml
@@ -65,6 +65,20 @@
     dest: "/tmp/template.test"
     validate: cat %s
 
+- name: "Attempt to template a missing src file with failed_when: false"
+  community.openwrt.template:
+    src: "does-not-exist.j2"
+    dest: "/tmp/template-missing.test"
+  register: template_missing
+  failed_when: false
+
+- name: Assert a missing src is reported as a normal result honoring failed_when
+  ansible.builtin.assert:
+    that:
+      - template_missing is not failed
+      - template_missing.failed_when_result == false
+      - "'msg' in template_missing"
+
 - name: Clean up test file
   community.openwrt.file:
     path: "/tmp/template.test"

--- a/tests/integration/targets/template/tasks/main.yml
+++ b/tests/integration/targets/template/tasks/main.yml
@@ -72,11 +72,6 @@
   register: template_missing
   failed_when: false
 
-- name: DEBUG dump full template_missing result
-  ansible.builtin.debug:
-    msg: "{{ template_missing }}"
-    verbosity: 0
-
 - name: Assert a missing src is reported as a normal result honoring failed_when
   ansible.builtin.assert:
     that:

--- a/tests/unit/plugins/action/test_template.py
+++ b/tests/unit/plugins/action/test_template.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2026, Alexei Znamensky (@russoz)
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from ansible.errors import AnsibleActionFail, AnsibleFileNotFound
+from ansible.plugins.action.template import ActionModule as CoreTemplateActionModule
+
+from ansible_collections.community.openwrt.plugins.action.template import ActionModule
+
+
+def _make_action():
+    obj = object.__new__(ActionModule)
+    obj._shared_loader_obj = MagicMock()
+    return obj
+
+
+def test_missing_src_returns_failed_result_instead_of_raising(mocker):
+    """ansible-core >= 2.19 lets AnsibleFileNotFound escape run(); it must be turned into a normal result."""
+    mocker.patch.object(
+        CoreTemplateActionModule,
+        "run",
+        side_effect=AnsibleFileNotFound(file_name="missing.j2", paths=["/templates/missing.j2"]),
+    )
+    action = _make_action()
+
+    result = action.run(task_vars={})
+
+    assert result["failed"] is True
+    assert "missing.j2" in result["msg"]
+
+
+def test_ansible_action_fail_result_is_preserved(mocker):
+    """An AnsibleActionFail raised by core must come back as its own contributed result dict."""
+    mocker.patch.object(CoreTemplateActionModule, "run", side_effect=AnsibleActionFail("src and dest are required"))
+    action = _make_action()
+
+    result = action.run(task_vars={})
+
+    assert result == {"failed": True, "msg": "src and dest are required"}
+
+
+def test_generic_exception_is_converted_to_failed_result(mocker):
+    """Any other exception escaping core's run() must also be converted, not raised."""
+    mocker.patch.object(CoreTemplateActionModule, "run", side_effect=ValueError("boom"))
+    action = _make_action()
+
+    result = action.run(task_vars={})
+
+    assert result == {"failed": True, "msg": "boom"}
+
+
+def test_successful_result_is_returned_unchanged(mocker):
+    """When core's run() succeeds normally, its result dict must be passed through untouched."""
+    mocker.patch.object(CoreTemplateActionModule, "run", return_value={"changed": True, "dest": "/etc/config"})
+    action = _make_action()
+
+    result = action.run(task_vars={})
+
+    assert result == {"changed": True, "dest": "/etc/config"}

--- a/tests/unit/plugins/action/test_template.py
+++ b/tests/unit/plugins/action/test_template.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from ansible.errors import AnsibleActionFail, AnsibleFileNotFound
+from ansible.errors import AnsibleAction, AnsibleActionFail, AnsibleFileNotFound
 from ansible.plugins.action.template import ActionModule as CoreTemplateActionModule
 
 from ansible_collections.community.openwrt.plugins.action.template import ActionModule
@@ -41,6 +41,18 @@ def test_ansible_action_fail_result_is_preserved(mocker):
     result = action.run(task_vars={})
 
     assert result == {"failed": True, "msg": "src and dest are required"}
+
+
+def test_bare_ansible_action_without_msg_falls_back_to_exception_text(mocker):
+    """A bare AnsibleAction contributes no "msg" of its own; some platforms have been observed
+    to raise AnsibleActionFail with a result lacking "msg" too, so the exception's own text
+    must still surface in the result either way."""
+    mocker.patch.object(CoreTemplateActionModule, "run", side_effect=AnsibleAction("could not find src=missing.j2"))
+    action = _make_action()
+
+    result = action.run(task_vars={})
+
+    assert "could not find src=missing.j2" in result["msg"]
 
 
 def test_generic_exception_is_converted_to_failed_result(mocker):

--- a/tests/unit/plugins/action/test_template.py
+++ b/tests/unit/plugins/action/test_template.py
@@ -34,13 +34,17 @@ def test_missing_src_returns_failed_result_instead_of_raising(mocker):
 
 
 def test_ansible_action_fail_result_is_preserved(mocker):
-    """An AnsibleActionFail raised by core must come back as its own contributed result dict."""
+    """An AnsibleActionFail raised by core must come back as its own contributed result dict.
+
+    The exact shape of that dict (e.g. whether "failed" or "exception" are present) varies
+    across ansible-core versions, so only the message content is asserted here.
+    """
     mocker.patch.object(CoreTemplateActionModule, "run", side_effect=AnsibleActionFail("src and dest are required"))
     action = _make_action()
 
     result = action.run(task_vars={})
 
-    assert result == {"failed": True, "msg": "src and dest are required"}
+    assert result["msg"] == "src and dest are required"
 
 
 def test_bare_ansible_action_without_msg_falls_back_to_exception_text(mocker):


### PR DESCRIPTION
## SUMMARY

ansible-core >= 2.19 (`ansible/ansible#84621`) removed the try/except in `ansible.plugins.action.template.ActionModule.run()` that used to keep it from ever raising. As a result, errors such as a missing `src` file now escape uncaught and bypass `failed_when`/`changed_when` evaluation entirely, turning what used to be a normal, controllable task failure into a fatal, unhandleable one.

Since `community.openwrt.template` subclasses that core action and delegates straight to it via `super().run()`, it inherited the same regression. This wraps the call and converts any escaping error back into a normal result dict, restoring the previous behavior where `failed_when: false` (or `ignore_errors`) can suppress a missing-`src` failure.

Root cause and reproduction with plain `ansible.builtin.template` (no collection involved) were tracked upstream at `ansible/ansible#87491`; this is a local workaround until/unless that gets fixed in ansible-core itself.

Fixes #252

## ISSUE TYPE
- Bugfix Pull Request

## COMPONENT NAME
template

## ADDITIONAL INFORMATION

Before this change, on ansible-core 2.19+:
```yaml
- name: Template a possibly-missing file
  community.openwrt.template:
    src: "does-not-exist.j2"
    dest: /etc/possibly-missing
  failed_when: false
```
```
[ERROR]: Task failed: Could not find or access 'does-not-exist.j2'
...
Task failed.
```
`failed_when: false` had no effect.

After this change, the same task returns a normal result honoring `failed_when`:
```json
{
    "changed": false,
    "failed": false,
    "failed_when_result": false,
    "msg": "Could not find or access 'does-not-exist.j2'\n..."
}
```
