### PR TITLE
service: note one-shot services are not idempotent for `state=started`

### DIFF
--- a/plugins/modules/service.py
+++ b/plugins/modules/service.py
@@ -11,6 +11,11 @@ short_description: Manage services on OpenWrt targets
 description:
   - The M(community.openwrt.service) module controls services on OpenWrt using init scripts.
   - It can start, stop, restart, reload services and manage their enabled state.
+  - Idempotency for O(state=started) and O(state=stopped) relies on the init script's C(running) check
+    (or O(pattern), when set). One-shot services that perform an action and exit, such as C(adblock),
+    always report as not running once finished, so O(state=started) reports RV(ignore:changed=true) on
+    every run for them. Manage such services with O(enabled) and only pass O(state) when the action is
+    explicitly wanted.
 author: Markus Weippert (@gekmihesg)
 extends_documentation_fragment:
   - community.openwrt.attributes


### PR DESCRIPTION
## SUMMARY

Issue #238 reports that `community.openwrt.service` with `state: started` returns `changed=true` on every run for the `adblock` service.

Root cause: `adblock` is a one-shot procd service — it builds its blocklist, reconfigures dnsmasq, and exits. Once finished, `/etc/init.d/adblock running` (via `procd_running` / `ubus call service list`) always reports `running: false`, so `set_state` sees the service as stopped and re-runs `start` every time. Long-running daemons (`dropbear`, `uhttpd`) are unaffected. The `pattern` option does not help here either, since a one-shot service leaves no process behind.

This is a limitation of how init scripts expose state rather than a defect in the module logic, so this PR documents the behavior in the module description and points users to `enabled` for managing such services.

Fixes #238

## ISSUE TYPE
- Docs Pull Request

## COMPONENT NAME
<!-- component-name-start -->
service
<!-- component-name-end -->

## ADDITIONAL INFORMATION

No changelog fragment: docs-only change.