### PR TITLE
ci: pr-auto-component should never fail

### DIFF
--- a/.github/workflows/pr-auto-component.yml
+++ b/.github/workflows/pr-auto-component.yml
@@ -6,7 +6,7 @@
 name: Populate Component Name
 
 on:  # yamllint disable-line rule:truthy
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:
@@ -17,14 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     # This job is best-effort: it tries to guess the component and fill it into
     # the PR description. If anything goes wrong, the workflow must still succeed.
+    #
+    # It never checks out the PR branch: the script below only reads the file
+    # list through the API, so running under pull_request_target is safe (no
+    # untrusted code is executed) while still getting a write-capable token for
+    # fork PRs.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
-        continue-on-error: true
-        with:
-          fetch-depth: 0
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-
       - name: Write changed files to temp file
         id: component
         uses: actions/github-script@v7

--- a/.github/workflows/pr-auto-component.yml
+++ b/.github/workflows/pr-auto-component.yml
@@ -15,14 +15,20 @@ permissions:
 jobs:
   update-pr-description:
     runs-on: ubuntu-latest
+    # This job is best-effort: it tries to guess the component and fill it into
+    # the PR description. If anything goes wrong, the workflow must still succeed.
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
+        continue-on-error: true
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Write changed files to temp file
+        id: component
         uses: actions/github-script@v7
+        continue-on-error: true
         with:
           script: |
             const fs = require('fs');
@@ -50,7 +56,10 @@ jobs:
             );
 
       - name: Update PR description
+        # Skip if the component could not be determined; the workflow still succeeds.
+        if: steps.component.outcome == 'success'
         uses: nefrob/pr-description@v1.2.0
+        continue-on-error: true
         with:
           content: /tmp/component.txt
           contentIsFilePath: true

--- a/.github/workflows/pr-auto-component.yml
+++ b/.github/workflows/pr-auto-component.yml
@@ -6,7 +6,7 @@
 name: Populate Component Name
 
 on:  # yamllint disable-line rule:truthy
-  pull_request_target:
+  pull_request:
     types: [opened]
 
 permissions:


### PR DESCRIPTION
## SUMMARY
<!-- Describe the change below, including rationale and design decisions -->
The workflow `.github/workflows/pr-auto-component.yml` attempts to automatically fill the component section of the description. If it cannot figure that out, this should not cause a failed task in the CI.


<!-- If you are fixing an existing issue, uncomment the line below and adjust the number -->
<!-- Fixes #nnnn -->

<!-- See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests -->


<!-- Please do not forget to include a changelog fragment:
     https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
     No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
     Read about more details in CONTRIBUTING.md. -->

## ISSUE TYPE
<!-- Pick one or more below and delete the rest.
     'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Test Pull Request

## COMPONENT NAME
<!-- This section will be filled automatically with the files changed in this PR.
     In case you want to do it, remove the start/end comments and
     write the SHORT NAME of the modules, plugins, tasks or features below. -->
<!-- component-name-start -->
<!-- component-name-end -->

## ADDITIONAL INFORMATION
<!-- Include additional information to help people understand the change here -->
<!-- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!-- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
